### PR TITLE
Extended javadoc for Conversion interface and Convert annotation

### DIFF
--- a/src/main/java/com/univocity/parsers/annotations/Convert.java
+++ b/src/main/java/com/univocity/parsers/annotations/Convert.java
@@ -21,8 +21,8 @@ import com.univocity.parsers.conversions.*;
 import java.lang.annotation.*;
 
 /**
- * Assigns a custom implementation of {@link Conversion} to be executed when writing to/reading from the field.
- *
+ * Assigns a custom implementation of {@link Conversion} to be executed ({@link Conversion#execute(Object)})
+ * when writing to the field and reverted ({@link Conversion#revert(Object)}) when reading from the field.
  *
  * @see Conversion
  * @see Conversions

--- a/src/main/java/com/univocity/parsers/conversions/Conversion.java
+++ b/src/main/java/com/univocity/parsers/conversions/Conversion.java
@@ -22,8 +22,11 @@ import com.univocity.parsers.common.processor.*;
  *
  * uniVocity-parsers provides a set of default conversions for usage with
  * {@link ObjectRowProcessor} and {@link ObjectRowWriterProcessor}.
- *
- * Annotations in package {@link com.univocity.parsers.annotations} are associated with different Conversion implementations in {@link com.univocity.parsers.conversions}.
+ * <p/>
+ * Annotations in package {@link com.univocity.parsers.annotations} are associated with different Conversion 
+ * implementations in {@link com.univocity.parsers.conversions}.
+ * <p/>
+ * When used in conjunction with the {@link com.univocity.parsers.annotations.Convert} annotation, 'O' is the same as the annotated POJO field.
  *
  * @param <I> The input type to be converted to the output type <b>O</b>
  * @param <O> The type of outputs produced by a conversion applied to the an input <b>I</b>
@@ -36,16 +39,21 @@ import com.univocity.parsers.common.processor.*;
 public interface Conversion<I, O> {
 
 	/**
-	 * Converts a value of type <b>I</b> to a value of type <b>O</b>
+	 * Converts a value of type <b>I</b> to a value of type <b>O</b>. 
+	 * Execute is for parsing. Conversions can be chained but the first will invariably start 
+	 * from a String (the original content parsed from a field) and the result of the conversion 
+	 * (or sequence of conversions) will be assigned to the annotated field.
 	 * @param input the input of type <b>I</b> to be converted to an object of type <b>O</b>
 	 * @return the conversion result.
 	 */
 	O execute(I input);
 
 	/**
-	 * Converts a value of type <b>O</b> to a value of type <b>I</b>
+	 * Converts a value of type <b>O</b> to a value of type <b>I</b>. Revert is used for writing. 
+	 * In this case your non-string value will be sent to the revert operation of a conversion to 
+	 * generate a String to be written to an output.
 	 * @param input the input of type <b>O</b> to be converted to an object of type <b>I</b>
-	 * @return the conversion result
+	 * @return the conversion result.
 	 */
 	I revert(O input);
 }


### PR DESCRIPTION
Clarified how the Conversion interface and the Convert annotation work in combination with Parsing and Writing csv. See #72 .