### PR TITLE
Handle single (double) quotes within double (single) quoted fields

### DIFF
--- a/src/main/java/com/univocity/parsers/csv/CsvFormatDetector.java
+++ b/src/main/java/com/univocity/parsers/csv/CsvFormatDetector.java
@@ -148,7 +148,6 @@ abstract class CsvFormatDetector implements InputAnalysisProcess {
 		sums.keySet().removeAll(toRemove);
 
 		char delimiter = min(sums, suggestedDelimiter);
-
 		char quote = doubleQuoteCount >= singleQuoteCount ? '"' : '\'';
 
 		escape.remove(delimiter);

--- a/src/main/java/com/univocity/parsers/csv/CsvFormatDetector.java
+++ b/src/main/java/com/univocity/parsers/csv/CsvFormatDetector.java
@@ -93,7 +93,7 @@ abstract class CsvFormatDetector implements InputAnalysisProcess {
 					}
 
 					inQuote = '\0';
-				} else {
+				} else if (inQuote == '\0') {
 					inQuote = ch;
 				}
 				continue;
@@ -148,6 +148,7 @@ abstract class CsvFormatDetector implements InputAnalysisProcess {
 		sums.keySet().removeAll(toRemove);
 
 		char delimiter = min(sums, suggestedDelimiter);
+
 		char quote = doubleQuoteCount >= singleQuoteCount ? '"' : '\'';
 
 		escape.remove(delimiter);

--- a/src/test/java/com/univocity/parsers/csv/CsvFormatDetectorTest.java
+++ b/src/test/java/com/univocity/parsers/csv/CsvFormatDetectorTest.java
@@ -29,14 +29,16 @@ public class CsvFormatDetectorTest {
 		return new Object[][]{
 			{"A,B,C\n1,2,3\n1,2,3\n1,2,3",
 				Arrays.asList(new String[]{"A", "B", "C"}, new String[]{"1", "2", "3"}, new String[]{"1", "2", "3"}, new String[]{"1", "2", "3"})},
-			{"\"A\";'B';\"C\"\n\"1\\\" and \\\"2\";\"3\\\"A\";'B';\"C\"\n\"A\";'B';\"C\"\n\"A\";'B';\"C\"\n",
-				Arrays.asList(new String[]{"A", "'B'", "C"}, new String[]{"1\" and \"2", "3\"A", "'B'", "C"}, new String[]{"A", "'B'", "C"}, new String[]{"A", "'B'", "C"})},
+			{"\"A\";'B';\"C\"\n\"1\\\" and \\\"2\";\"3' and '4\";\"5\\\" and \\\"6\"\n\"A\";'B';\"C\"\n\"A\";'B';\"C\"\n",
+				Arrays.asList(new String[]{"A", "'B'", "C"}, new String[]{"1\" and \"2", "3' and '4", "5\" and \"6"}, new String[]{"A", "'B'", "C"}, new String[]{"A", "'B'", "C"})},
 			{"1,2;2,3;3,4\n1,2;2,3;3,4\n1,2;2,3;3,4\n1,2;2,3;3,4\n",
 				Arrays.asList(new String[]{"1,2", "2,3", "3,4"}, new String[]{"1,2", "2,3", "3,4"}, new String[]{"1,2", "2,3", "3,4"}, new String[]{"1,2", "2,3", "3,4"})},
 			{
 				"A;B;C;D;E\n$1.2;$2.3;$3.4\n$1.2;$2.3;$3.4\n$1.2;$2.3;$3.4\n$1.2;$2.3;$3.4\n",
 				Arrays.asList(new String[]{"A", "B", "C", "D", "E"}, new String[]{"$1.2", "$2.3", "$3.4"}, new String[]{"$1.2", "$2.3", "$3.4"}, new String[]{"$1.2", "$2.3", "$3.4"},
-					new String[]{"$1.2", "$2.3", "$3.4"})}
+					new String[]{"$1.2", "$2.3", "$3.4"})},
+			{"\"A'A\",\"BB\",\"CC\"\n\"11\",\"22\",\"33\"\n\"11\",\"22\",\"33\"\n\"11\",\"22\",\"33\"\n",
+				Arrays.asList(new String[]{"A'A", "BB", "CC"}, new String[]{"11", "22", "33"}, new String[] {"11", "22", "33"}, new String[] {"11", "22", "33"})}
 
 		};
 	}


### PR DESCRIPTION
Input lines such as
```
"One","Two's the best","Three","Four"
```
would cause detection to fail because the lone single quote would cause the detector to change `inQuote` to a single quote before finding the closing double quote.