### PR TITLE
Alter CSV and TSV setter methods to return self

### DIFF
--- a/src/main/java/com/univocity/parsers/common/CommonSettings.java
+++ b/src/main/java/com/univocity/parsers/common/CommonSettings.java
@@ -104,8 +104,9 @@ public abstract class CommonSettings<F extends Format> implements Cloneable {
 	 *
 	 * @param emptyValue the String representation of a null value
 	 */
-	public void setNullValue(String emptyValue) {
+	public CommonSettings setNullValue(String emptyValue) {
 		this.nullValue = emptyValue;
+		return this;
 	}
 
 	/**
@@ -126,8 +127,9 @@ public abstract class CommonSettings<F extends Format> implements Cloneable {
 	 *
 	 * @param maxCharsPerColumn The maximum number of characters allowed for any given value being written/read
 	 */
-	public void setMaxCharsPerColumn(int maxCharsPerColumn) {
+	public CommonSettings setMaxCharsPerColumn(int maxCharsPerColumn) {
 		this.maxCharsPerColumn = maxCharsPerColumn;
+		return this;
 	}
 
 	/**
@@ -148,8 +150,9 @@ public abstract class CommonSettings<F extends Format> implements Cloneable {
 	 *
 	 * @param skipEmptyLines true if empty lines should be ignored, false otherwise
 	 */
-	public void setSkipEmptyLines(boolean skipEmptyLines) {
+	public CommonSettings setSkipEmptyLines(boolean skipEmptyLines) {
 		this.skipEmptyLines = skipEmptyLines;
+		return this;
 	}
 
 	/**
@@ -166,8 +169,9 @@ public abstract class CommonSettings<F extends Format> implements Cloneable {
 	 *
 	 * @param ignoreTrailingWhitespaces true if trailing whitespaces from values being read/written should be skipped, false otherwise
 	 */
-	public void setIgnoreTrailingWhitespaces(boolean ignoreTrailingWhitespaces) {
+	public CommonSettings setIgnoreTrailingWhitespaces(boolean ignoreTrailingWhitespaces) {
 		this.ignoreTrailingWhitespaces = ignoreTrailingWhitespaces;
+		return this;
 	}
 
 	/**
@@ -184,8 +188,9 @@ public abstract class CommonSettings<F extends Format> implements Cloneable {
 	 *
 	 * @param ignoreLeadingWhitespaces true if leading whitespaces from values being read/written should be skipped, false otherwise
 	 */
-	public void setIgnoreLeadingWhitespaces(boolean ignoreLeadingWhitespaces) {
+	public CommonSettings setIgnoreLeadingWhitespaces(boolean ignoreLeadingWhitespaces) {
 		this.ignoreLeadingWhitespaces = ignoreLeadingWhitespaces;
+		return this;
 	}
 
 	/**
@@ -195,12 +200,14 @@ public abstract class CommonSettings<F extends Format> implements Cloneable {
 	 *
 	 * @param headers the field name sequence associated with each column in the input/output.
 	 */
-	public void setHeaders(String... headers) {
+	public CommonSettings setHeaders(String... headers) {
 		if (headers == null || headers.length == 0) {
 			this.headers = null;
 		} else {
 			this.headers = headers;
 		}
+
+		return this;
 	}
 
 	/**
@@ -211,9 +218,10 @@ public abstract class CommonSettings<F extends Format> implements Cloneable {
 	 * @param headerSourceClass the class from which the headers have been derived.
 	 * @param headers           the field name sequence associated with each column in the input/output.
 	 */
-	void setHeadersDerivedFromClass(Class<?> headerSourceClass, String... headers) {
+	public CommonSettings setHeadersDerivedFromClass(Class<?> headerSourceClass, String... headers) {
 		this.headerSourceClass = headerSourceClass;
 		setHeaders(headers);
+		return this;
 	}
 
 	/**
@@ -261,8 +269,9 @@ public abstract class CommonSettings<F extends Format> implements Cloneable {
 	 *
 	 * @param maxColumns The maximum number of columns a record can have.
 	 */
-	public void setMaxColumns(int maxColumns) {
+	public CommonSettings setMaxColumns(int maxColumns) {
 		this.maxColumns = maxColumns;
+		return this;
 	}
 
 	/**
@@ -279,11 +288,12 @@ public abstract class CommonSettings<F extends Format> implements Cloneable {
 	 *
 	 * @param format The format of the file to be parsed/written
 	 */
-	public void setFormat(F format) {
+	public CommonSettings setFormat(F format) {
 		if (format == null) {
 			throw new IllegalArgumentException("Format cannot be null");
 		}
 		this.format = format;
+		return this;
 	}
 
 	/**
@@ -467,8 +477,9 @@ public abstract class CommonSettings<F extends Format> implements Cloneable {
 	 *
 	 * @param autoConfigurationEnabled a flag to turn the automatic configuration feature on/off.
 	 */
-	public final void setAutoConfigurationEnabled(boolean autoConfigurationEnabled) {
+	public CommonSettings setAutoConfigurationEnabled(boolean autoConfigurationEnabled) {
 		this.autoConfigurationEnabled = autoConfigurationEnabled;
+		return this;
 	}
 
 	/**
@@ -499,8 +510,9 @@ public abstract class CommonSettings<F extends Format> implements Cloneable {
 	 * Implementations based on {@link RowProcessorErrorHandler} allow only parsers who provide a {@link ParsingContext} to be used.
 	 */
 	@Deprecated
-	public void setRowProcessorErrorHandler(RowProcessorErrorHandler rowProcessorErrorHandler) {
+	public CommonSettings setRowProcessorErrorHandler(RowProcessorErrorHandler rowProcessorErrorHandler) {
 		this.errorHandler = rowProcessorErrorHandler;
+		return this;
 	}
 
 	/**
@@ -525,8 +537,9 @@ public abstract class CommonSettings<F extends Format> implements Cloneable {
 	 *
 	 * @param processorErrorHandler the callback error handler with custom code to manage occurrences of {@link DataProcessingException}.
 	 */
-	public void setProcessorErrorHandler(ProcessorErrorHandler<? extends Context> processorErrorHandler) {
+	public CommonSettings setProcessorErrorHandler(ProcessorErrorHandler<? extends Context> processorErrorHandler) {
 		this.errorHandler = processorErrorHandler;
+		return this;
 	}
 
 
@@ -561,9 +574,10 @@ public abstract class CommonSettings<F extends Format> implements Cloneable {
 	 *
 	 * @param trim a flag indicating whether the whitespaces should remove whitespaces around values parsed/written.
 	 */
-	public final void trimValues(boolean trim) {
+	public final CommonSettings trimValues(boolean trim) {
 		this.setIgnoreLeadingWhitespaces(trim);
 		this.setIgnoreTrailingWhitespaces(trim);
+		return this;
 	}
 
 	/**
@@ -590,8 +604,9 @@ public abstract class CommonSettings<F extends Format> implements Cloneable {
 	 *
 	 * @param errorContentLength maximum length of contents displayed in exception messages in case of errors while parsing/writing.
 	 */
-	public void setErrorContentLength(int errorContentLength) {
+	public CommonSettings setErrorContentLength(int errorContentLength) {
 		this.errorContentLength = errorContentLength;
+		return this;
 	}
 
 	void runAutomaticConfiguration() {
@@ -627,8 +642,9 @@ public abstract class CommonSettings<F extends Format> implements Cloneable {
 	 *
 	 * @param skipBitsAsWhitespace a flag indicating whether bit values (0 or 1) should be considered whitespace.
 	 */
-	public final void setSkipBitsAsWhitespace(boolean skipBitsAsWhitespace) {
+	public CommonSettings setSkipBitsAsWhitespace(boolean skipBitsAsWhitespace) {
 		this.skipBitsAsWhitespace = skipBitsAsWhitespace;
+		return this;
 	}
 
 	/**

--- a/src/main/java/com/univocity/parsers/common/Format.java
+++ b/src/main/java/com/univocity/parsers/common/Format.java
@@ -102,18 +102,19 @@ public abstract class Format implements Cloneable{
 	 * Defines the line separator sequence that should be used for parsing and writing.
 	 * @param lineSeparator a sequence of 1 to 2 characters that identifies the end of a line
 	 */
-	public void setLineSeparator(String lineSeparator) {
+	public Format setLineSeparator(String lineSeparator) {
 		if (lineSeparator == null || lineSeparator.isEmpty()) {
 			throw new IllegalArgumentException("Line separator cannot be empty");
 		}
 		setLineSeparator(lineSeparator.toCharArray());
+		return this;
 	}
 
 	/**
 	 * Defines the line separator sequence that should be used for parsing and writing.
 	 * @param lineSeparator a sequence of 1 to 2 characters that identifies the end of a line
 	 */
-	public void setLineSeparator(char[] lineSeparator) {
+	public Format setLineSeparator(char[] lineSeparator) {
 		if (lineSeparator == null || lineSeparator.length == 0) {
 			throw new IllegalArgumentException("Invalid line separator. Expected 1 to 2 characters");
 		}
@@ -125,6 +126,7 @@ public abstract class Format implements Cloneable{
 		if(lineSeparator.length == 1){
 			setNormalizedNewline(lineSeparator[0]);
 		}
+		return this;
 	}
 
 	/**
@@ -139,8 +141,9 @@ public abstract class Format implements Cloneable{
 	 * Sets the normalized newline character, which is automatically replaced by {@link Format#lineSeparator} when reading/writing
 	 * @param normalizedNewline a single character used to represent a line separator.
 	 */
-	public void setNormalizedNewline(char normalizedNewline) {
+	public Format setNormalizedNewline(char normalizedNewline) {
 		this.normalizedNewline = normalizedNewline;
+		return this;
 	}
 
 	/**
@@ -166,8 +169,9 @@ public abstract class Format implements Cloneable{
 	 * <p> Use '\0' to disable comment skipping.
 	 * @param comment the comment character
 	 */
-	public void setComment(char comment) {
+	public Format setComment(char comment) {
 		this.comment = comment;
+		return this;
 	}
 
 	/**

--- a/src/main/java/com/univocity/parsers/csv/CsvFormat.java
+++ b/src/main/java/com/univocity/parsers/csv/CsvFormat.java
@@ -55,9 +55,12 @@ public class CsvFormat extends Format {
 	 * Defines the character used for escaping values where the field delimiter is part of the value. Defaults to '"'
 	 *
 	 * @param quote the quote character
+	 *
+	 * @return this {@code CsvFormat} instance
 	 */
-	public void setQuote(char quote) {
+	public CsvFormat setQuote(char quote) {
 		this.quote = quote;
+		return this;
 	}
 
 	/**
@@ -84,9 +87,12 @@ public class CsvFormat extends Format {
 	 * Defines the character used for escaping quotes inside an already quoted value. Defaults to '"'
 	 *
 	 * @param quoteEscape the quote escape character
+	 *
+	 * @return this {@code CsvFormat} instance
 	 */
-	public void setQuoteEscape(char quoteEscape) {
+	public CsvFormat setQuoteEscape(char quoteEscape) {
 		this.quoteEscape = quoteEscape;
+		return this;
 	}
 
 	/**
@@ -125,17 +131,22 @@ public class CsvFormat extends Format {
 	 * Defines the field delimiter character. Defaults to ','
 	 *
 	 * @param delimiter the field delimiter character
+	 *
+	 * @return this {@code CsvFormat} instance
 	 */
-	public void setDelimiter(char delimiter) {
+	public CsvFormat setDelimiter(char delimiter) {
 		this.delimiter = String.valueOf(delimiter);
+		return this;
 	}
 
 	/**
 	 * Defines the field delimiter as a sequence of characters. Defaults to ','
 	 *
 	 * @param delimiter the field delimiter sequence.
+	 *
+	 * @return this {@code CsvFormat} instance
 	 */
-	public void setDelimiter(String delimiter) {
+	public CsvFormat setDelimiter(String delimiter) {
 		if (delimiter == null) {
 			throw new IllegalArgumentException("Delimiter cannot be null");
 		}
@@ -143,6 +154,7 @@ public class CsvFormat extends Format {
 			throw new IllegalArgumentException("Delimiter cannot be empty");
 		}
 		this.delimiter = delimiter;
+		return this;
 	}
 
 	/**
@@ -214,9 +226,12 @@ public class CsvFormat extends Format {
 	 * Defaults to '\0' (undefined)
 	 *
 	 * @param charToEscapeQuoteEscaping the character to escape the character used for escaping quotes defined
+	 *
+	 * @return this {@code CsvFormat} instance
 	 */
-	public final void setCharToEscapeQuoteEscaping(char charToEscapeQuoteEscaping) {
+	public final CsvFormat setCharToEscapeQuoteEscaping(char charToEscapeQuoteEscaping) {
 		this.charToEscapeQuoteEscaping = charToEscapeQuoteEscaping;
+		return this;
 	}
 
 	/**
@@ -229,6 +244,55 @@ public class CsvFormat extends Format {
 	public final boolean isCharToEscapeQuoteEscaping(char ch) {
 		char current = getCharToEscapeQuoteEscaping();
 		return current != '\0' && current == ch;
+	}
+
+	/**
+	 * Defines the line separator sequence that should be used for parsing and writing.
+	 *
+	 * @param lineSeparator a sequence of 1 to 2 characters that identifies the end of a line
+	 *
+	 * @return this {@code CsvFormat} instance
+	 */
+	public CsvFormat setLineSeparator(String lineSeparator) {
+		super.setLineSeparator(lineSeparator);
+		return this;
+	}
+
+	/**
+	 * Defines the line separator sequence that should be used for parsing and writing.
+	 *
+	 * @param lineSeparator a sequence of 1 to 2 characters that identifies the end of a line
+	 *
+	 * @return this {@code CsvFormat} instance
+	 */
+	public CsvFormat setLineSeparator(char[] lineSeparator) {
+		super.setLineSeparator(lineSeparator);
+		return this;
+	}
+
+	/**
+	 * Sets the normalized newline character, which is automatically replaced by {@link Format#getLineSeparator} when reading/writing
+	 *
+	 * @param normalizedNewline a single character used to represent a line separator.
+	 *
+	 * @return this {@code CsvFormat} instance
+	 */
+	public CsvFormat setNormalizedNewline(char normalizedNewline) {
+		super.setNormalizedNewline(normalizedNewline);
+		return this;
+	}
+
+	/**
+	 * Defines the character that represents a line comment when found in the beginning of a line of text. Defaults to '#'
+	 * <p> Use '\0' to disable comment skipping.
+	 *
+	 * @param comment the comment character
+	 *
+	 * @return this {@code CsvFormat} instance
+	 */
+	public CsvFormat setComment(char comment) {
+		super.setComment(comment);
+		return this;
 	}
 
 	@Override

--- a/src/main/java/com/univocity/parsers/csv/CsvParserSettings.java
+++ b/src/main/java/com/univocity/parsers/csv/CsvParserSettings.java
@@ -15,8 +15,11 @@
  ******************************************************************************/
 package com.univocity.parsers.csv;
 
+import com.univocity.parsers.annotations.Parsed;
+import com.univocity.parsers.annotations.Headers;
 import com.univocity.parsers.common.*;
 import com.univocity.parsers.common.input.*;
+import com.univocity.parsers.common.processor.*;
 
 import java.util.*;
 
@@ -70,9 +73,12 @@ public class CsvParserSettings extends CommonParserSettings<CsvFormat> {
 	 * <p>When reading, if the parser does not read any character from the input, and the input is within quotes, the empty is used instead of an empty string
 	 *
 	 * @param emptyValue the String representation of an empty value
+	 *
+	 * @return this {@code CsvParserSettings} instance
 	 */
-	public void setEmptyValue(String emptyValue) {
+	public CsvParserSettings setEmptyValue(String emptyValue) {
 		this.emptyValue = emptyValue;
+		return this;
 	}
 
 	/**
@@ -95,7 +101,7 @@ public class CsvParserSettings extends CommonParserSettings<CsvFormat> {
 	/**
 	 * Returns the default CsvFormat configured to handle CSV inputs compliant to the <a href="http://tools.ietf.org/html/rfc4180">RFC4180</a> standard.
 	 *
-	 * @return and instance of CsvFormat configured to handle CSV inputs compliant to the <a href="http://tools.ietf.org/html/rfc4180">RFC4180</a> standard.
+	 * @return an instance of CsvFormat configured to handle CSV inputs compliant to the <a href="http://tools.ietf.org/html/rfc4180">RFC4180</a> standard.
 	 */
 	@Override
 	protected CsvFormat createDefaultFormat() {
@@ -120,11 +126,14 @@ public class CsvParserSettings extends CommonParserSettings<CsvFormat> {
 	 *
 	 * @param parseUnescapedQuotes indicates whether or not the CSV parser should accept unescaped quotes inside quoted values.
 	 *
+	 * @return this {@code CsvParserSettings} instance
+	 *
 	 * @deprecated use {@link #setUnescapedQuoteHandling(UnescapedQuoteHandling)} instead. The configuration returned by {@link #getUnescapedQuoteHandling()} will override this setting if not null.
 	 */
 	@Deprecated
-	public void setParseUnescapedQuotes(boolean parseUnescapedQuotes) {
+	public CsvParserSettings setParseUnescapedQuotes(boolean parseUnescapedQuotes) {
 		this.parseUnescapedQuotes = parseUnescapedQuotes;
+		return this;
 	}
 
 	/**
@@ -134,14 +143,17 @@ public class CsvParserSettings extends CommonParserSettings<CsvFormat> {
 	 * @param parseUnescapedQuotesUntilDelimiter a flag indicating that the parser should stop accumulating values when a field delimiter character is
 	 *                                           found when parsing unquoted and unescaped values.
 	 *
+	 * @return this {@code CsvParserSettings} instance
+	 *
 	 * @deprecated use {@link #setUnescapedQuoteHandling(UnescapedQuoteHandling)} instead. The configuration returned by {@link #getUnescapedQuoteHandling()} will override this setting if not null.
 	 */
 	@Deprecated
-	public void setParseUnescapedQuotesUntilDelimiter(boolean parseUnescapedQuotesUntilDelimiter) {
+	public CsvParserSettings setParseUnescapedQuotesUntilDelimiter(boolean parseUnescapedQuotesUntilDelimiter) {
 		if (parseUnescapedQuotesUntilDelimiter) {
 			parseUnescapedQuotes = true;
 		}
 		this.parseUnescapedQuotesUntilDelimiter = parseUnescapedQuotesUntilDelimiter;
+		return this;
 	}
 
 	/**
@@ -179,9 +191,12 @@ public class CsvParserSettings extends CommonParserSettings<CsvFormat> {
 	 * to process escape sequences in unquoted values, the result will be {@code [A"B] and [C]}</p>
 	 *
 	 * @param escapeUnquotedValues a flag indicating whether escape sequences should be processed in unquoted values
+	 *
+	 * @return this {@code CsvParserSettings} instance
 	 */
-	public void setEscapeUnquotedValues(boolean escapeUnquotedValues) {
+	public CsvParserSettings setEscapeUnquotedValues(boolean escapeUnquotedValues) {
 		this.escapeUnquotedValues = escapeUnquotedValues;
+		return this;
 	}
 
 	/**
@@ -199,9 +214,12 @@ public class CsvParserSettings extends CommonParserSettings<CsvFormat> {
 	 * <p>This is disabled by default</p>
 	 *
 	 * @param keepEscapeSequences the flag indicating whether escape sequences should be kept (and not replaced) by the parser.
+	 *
+	 * @return this {@code CsvParserSettings} instance
 	 */
-	public final void setKeepEscapeSequences(boolean keepEscapeSequences) {
+	public final CsvParserSettings setKeepEscapeSequences(boolean keepEscapeSequences) {
 		this.keepEscapeSequences = keepEscapeSequences;
+		return this;
 	}
 
 	/**
@@ -223,10 +241,13 @@ public class CsvParserSettings extends CommonParserSettings<CsvFormat> {
 	 * @param separatorDetectionEnabled the flag to enable/disable discovery of the column delimiter character.
 	 * @param delimitersForDetection possible delimiters for detection when {@link #isDelimiterDetectionEnabled()} evaluates
 	 * to {@code true}, in order of priority.
+	 *
+	 * @return this {@code CsvParserSettings} instance
 	 */
-	public final void setDelimiterDetectionEnabled(boolean separatorDetectionEnabled, char... delimitersForDetection) {
+	public final CsvParserSettings setDelimiterDetectionEnabled(boolean separatorDetectionEnabled, char... delimitersForDetection) {
 		this.delimiterDetectionEnabled = separatorDetectionEnabled;
 		this.delimitersForDetection = delimitersForDetection;
+		return this;
 	}
 
 	/**
@@ -246,9 +267,12 @@ public class CsvParserSettings extends CommonParserSettings<CsvFormat> {
 	 * In this case the characters provided by {@link CsvFormat#getQuote()} and {@link CsvFormat#getQuoteEscape()} will be used </p>
 	 *
 	 * @param quoteDetectionEnabled the flag to enable/disable discovery of the quote character. The quote escape will also be detected as part of this process.
+	 *
+	 * @return this {@code CsvParserSettings} instance
 	 */
-	public final void setQuoteDetectionEnabled(boolean quoteDetectionEnabled) {
+	public final CsvParserSettings setQuoteDetectionEnabled(boolean quoteDetectionEnabled) {
 		this.quoteDetectionEnabled = quoteDetectionEnabled;
+		return this;
 	}
 
 	/**
@@ -260,11 +284,14 @@ public class CsvParserSettings extends CommonParserSettings<CsvFormat> {
 	 * </ul>
 	 *
 	 * @param delimitersForDetection possible delimiters for detection, in order of priority.
+	 *
+	 * @return this {@code CsvParserSettings} instance
 	 */
-	public final void detectFormatAutomatically(char... delimitersForDetection) {
+	public final CsvParserSettings detectFormatAutomatically(char... delimitersForDetection) {
 		this.setDelimiterDetectionEnabled(true, delimitersForDetection);
 		this.setQuoteDetectionEnabled(true);
 		this.setLineSeparatorDetectionEnabled(true);
+		return this;
 	}
 
 	/**
@@ -307,9 +334,12 @@ public class CsvParserSettings extends CommonParserSettings<CsvFormat> {
 	 *
 	 * @param normalizeLineEndingsWithinQuotes flag indicating whether line separators in quoted values should be replaced by
 	 *                                         the the character specified in {@link Format#getNormalizedNewline()} .
+	 *
+	 * @return this {@code CsvParserSettings} instance
 	 */
-	public void setNormalizeLineEndingsWithinQuotes(boolean normalizeLineEndingsWithinQuotes) {
+	public CsvParserSettings setNormalizeLineEndingsWithinQuotes(boolean normalizeLineEndingsWithinQuotes) {
 		this.normalizeLineEndingsWithinQuotes = normalizeLineEndingsWithinQuotes;
+		return this;
 	}
 
 	/**
@@ -318,9 +348,12 @@ public class CsvParserSettings extends CommonParserSettings<CsvFormat> {
 	 * If set to a non-null value, this setting will override the configuration of {@link #isParseUnescapedQuotes()} and {@link #isParseUnescapedQuotesUntilDelimiter()}.
 	 *
 	 * @param unescapedQuoteHandling the handling method to be used when unescaped quotes are found in the input.
+	 *
+	 * @return this {@code CsvParserSettings} instance
 	 */
-	public void setUnescapedQuoteHandling(UnescapedQuoteHandling unescapedQuoteHandling) {
+	public CsvParserSettings setUnescapedQuoteHandling(UnescapedQuoteHandling unescapedQuoteHandling) {
 		this.unescapedQuoteHandling = unescapedQuoteHandling;
+		return this;
 	}
 
 	/**
@@ -350,9 +383,12 @@ public class CsvParserSettings extends CommonParserSettings<CsvFormat> {
 	 * <p>Defaults to {@code false}</p>
 	 *
 	 * @param keepQuotes flag indicating whether enclosing quotes should be maintained when parsing quoted values.
+	 *
+	 * @return this {@code CsvParserSettings} instance
 	 */
-	public void setKeepQuotes(boolean keepQuotes) {
+	public CsvParserSettings setKeepQuotes(boolean keepQuotes) {
 		this.keepQuotes = keepQuotes;
+		return this;
 	}
 
 	@Override
@@ -408,9 +444,12 @@ public class CsvParserSettings extends CommonParserSettings<CsvFormat> {
 	 * Note: if {@link #keepQuotes} evaluates to {@code true}, values won't be trimmed.
 	 *
 	 * @param ignoreTrailingWhitespacesInQuotes whether trailing whitespaces from quoted values should be skipped
+	 *
+	 * @return this {@code CsvParserSettings} instance
 	 */
-	public void setIgnoreTrailingWhitespacesInQuotes(boolean ignoreTrailingWhitespacesInQuotes) {
+	public CsvParserSettings setIgnoreTrailingWhitespacesInQuotes(boolean ignoreTrailingWhitespacesInQuotes) {
 		this.ignoreTrailingWhitespacesInQuotes = ignoreTrailingWhitespacesInQuotes;
+		return this;
 	}
 
 	/**
@@ -430,9 +469,12 @@ public class CsvParserSettings extends CommonParserSettings<CsvFormat> {
 	 * Note: if {@link #keepQuotes} evaluates to {@code true}, values won't be trimmed.
 	 *
 	 * @param ignoreLeadingWhitespacesInQuotes whether leading whitespaces from quoted values should be skipped
+	 *
+	 * @return this {@code CsvParserSettings} instance
 	 */
-	public void setIgnoreLeadingWhitespacesInQuotes(boolean ignoreLeadingWhitespacesInQuotes) {
+	public CsvParserSettings setIgnoreLeadingWhitespacesInQuotes(boolean ignoreLeadingWhitespacesInQuotes) {
 		this.ignoreLeadingWhitespacesInQuotes = ignoreLeadingWhitespacesInQuotes;
+		return this;
 	}
 
 	/**
@@ -442,9 +484,216 @@ public class CsvParserSettings extends CommonParserSettings<CsvFormat> {
 	 * Note: if {@link #keepQuotes} evaluates to {@code true}, values won't be trimmed.
 	 *
 	 * @param trim a flag indicating whether whitespaces around values extracted from a quoted field should be removed
+	 *
+	 * @return this {@code CsvParserSettings} instance
 	 */
-	public final void trimQuotedValues(boolean trim) {
+	public final CsvParserSettings trimQuotedValues(boolean trim) {
 		setIgnoreTrailingWhitespacesInQuotes(trim);
 		setIgnoreLeadingWhitespacesInQuotes(trim);
+		return this;
+	}
+
+	/**
+	 * Sets the String representation of a null value (defaults to null)
+	 * <p>When reading, if the parser does not read any character from the input, the nullValue is used instead of an empty string
+	 * <p>When writing, if the writer has a null object to write to the output, the nullValue is used instead of an empty string
+	 *
+	 * @param emptyValue the String representation of a null value
+	 *
+	 * @return this {@code CsvParserSettings} instance
+	 */
+	public CsvParserSettings setNullValue(String emptyValue) {
+		super.setNullValue(emptyValue);
+		return this;
+	}
+
+	/**
+	 * Defines the maximum number of characters allowed for any given value being written/read. Used to avoid OutOfMemoryErrors (defaults to 4096).
+	 *
+	 * <p>To enable auto-expansion of the internal array, set this property to -1</p>
+	 *
+	 * @param maxCharsPerColumn The maximum number of characters allowed for any given value being written/read
+	 *
+	 * @return this {@code CsvParserSettings} instance
+	 */
+	public CsvParserSettings setMaxCharsPerColumn(int maxCharsPerColumn) {
+		super.setMaxCharsPerColumn(maxCharsPerColumn);
+		return this;
+	}
+
+	/**
+	 * Defines whether or not empty lines should be ignored (defaults to true)
+	 * <p>when reading, if the parser reads a line that is empty, it will be skipped.
+	 * <p>when writing, if the writer receives an empty or null row to write to the output, it will be ignored
+	 *
+	 * @param skipEmptyLines true if empty lines should be ignored, false otherwise
+	 *
+	 * @return this {@code CsvParserSettings} instance
+	 */
+	public CsvParserSettings setSkipEmptyLines(boolean skipEmptyLines) {
+		super.setSkipEmptyLines(skipEmptyLines);
+		return this;
+	}
+
+	/**
+	 * Defines whether or not trailing whitespaces from values being read/written should be skipped  (defaults to true)
+	 *
+	 * @param ignoreTrailingWhitespaces true if trailing whitespaces from values being read/written should be skipped, false otherwise
+	 *
+	 * @return this {@code CsvParserSettings} instance
+	 */
+	public CsvParserSettings setIgnoreTrailingWhitespaces(boolean ignoreTrailingWhitespaces) {
+		super.setIgnoreTrailingWhitespaces(ignoreTrailingWhitespaces);
+		return this;
+	}
+
+	/**
+	 * Defines whether or not leading whitespaces from values being read/written should be skipped  (defaults to true)
+	 *
+	 * @param ignoreLeadingWhitespaces true if leading whitespaces from values being read/written should be skipped, false otherwise
+	 *
+	 * @return this {@code CsvParserSettings} instance
+	 */
+	public CsvParserSettings setIgnoreLeadingWhitespaces(boolean ignoreLeadingWhitespaces) {
+		super.setIgnoreLeadingWhitespaces(ignoreLeadingWhitespaces);
+		return this;
+	}
+
+	/**
+	 * Defines the field names in the input/output, in the sequence they occur (defaults to null).
+	 * <p>when reading, the given header names will be used to refer to each column irrespective of whether or not the input contains a header row
+	 * <p>when writing, the given header names will be used to refer to each column and can be used for writing the header row
+	 *
+	 * @param headers the field name sequence associated with each column in the input/output.
+	 *
+	 * @return this {@code CsvParserSettings} instance
+	 */
+	public CsvParserSettings setHeaders(String... headers) {
+		super.setHeaders(headers);
+		return this;
+	}
+
+	/**
+	 * Defines the field names in the input/output derived from a given class with {@link Parsed} annotated attributes/methods.
+	 * <p>when reading, the given header names will be used to refer to each column irrespective of whether or not the input contains a header row
+	 * <p>when writing, the given header names will be used to refer to each column and can be used for writing the header row
+	 *
+	 * @param headerSourceClass the class from which the headers have been derived.
+	 * @param headers           the field name sequence associated with each column in the input/output.
+	 *
+	 * @return this {@code CsvParserSettings} instance
+	 */
+	public CsvParserSettings setHeadersDerivedFromClass(Class<?> headerSourceClass, String... headers) {
+		super.setHeadersDerivedFromClass(headerSourceClass, headers);
+		return this;
+	}
+
+	/**
+	 * Defines a hard limit of how many columns a record can have (defaults to 512).
+	 * You need this to avoid OutOfMemory errors in case of inputs that might be inconsistent with the format you are dealing with.
+	 *
+	 * @param maxColumns The maximum number of columns a record can have.
+	 *
+	 * @return this {@code CsvParserSettings} instance
+	 */
+	public CsvParserSettings setMaxColumns(int maxColumns) {
+		super.setMaxColumns(maxColumns);
+		return this;
+	}
+
+	/**
+	 * Defines the format of the file to be parsed/written (returns the format's defaults).
+	 *
+	 * @param format The format of the file to be parsed/written
+	 *
+	 * @return this {@code CsvParserSettings} instance
+	 */
+	public CsvParserSettings setFormat(CsvFormat format) {
+		super.setFormat(format);
+		return this;
+	}
+
+	/**
+	 * Indicates whether this settings object can automatically derive configuration options. This is used, for example, to define the headers when the user
+	 * provides a {@link BeanWriterProcessor} where the bean class contains a {@link Headers} annotation, or to enable header extraction when the bean class of a
+	 * {@link BeanProcessor} has attributes mapping to header names.
+	 *
+	 * @param autoConfigurationEnabled a flag to turn the automatic configuration feature on/off.
+	 *
+	 * @return this {@code CsvParserSettings} instance
+	 */
+	public final CsvParserSettings setAutoConfigurationEnabled(boolean autoConfigurationEnabled) {
+		super.setAutoConfigurationEnabled(autoConfigurationEnabled);
+		return this;
+	}
+
+	/**
+	 * Defines a custom error handler to capture and handle errors that might happen while processing records with a {@link RowProcessor}
+	 * or a {@link RowWriterProcessor} (i.e. non-fatal {@link DataProcessingException}s).
+	 *
+	 * <p>The parsing parsing/writing won't stop (unless the error handler rethrows the {@link DataProcessingException} or manually stops the process).</p>
+	 *
+	 * @param rowProcessorErrorHandler the callback error handler with custom code to manage occurrences of {@link DataProcessingException}.
+	 *
+	 * @return this {@code CsvParserSettings} instance
+	 *
+	 * @deprecated Use the {@link #setProcessorErrorHandler(ProcessorErrorHandler)} method as it allows format-specific error handlers to be built to work with different implementations of {@link Context}.
+	 * Implementations based on {@link RowProcessorErrorHandler} allow only parsers who provide a {@link ParsingContext} to be used.
+	 */
+	@Deprecated
+	public CsvParserSettings setRowProcessorErrorHandler(RowProcessorErrorHandler rowProcessorErrorHandler) {
+		super.setRowProcessorErrorHandler(rowProcessorErrorHandler);
+		return this;
+	}
+
+	/**
+	 * Defines a custom error handler to capture and handle errors that might happen while processing records with a {@link com.univocity.parsers.common.processor.core.Processor}
+	 * or a {@link RowWriterProcessor} (i.e. non-fatal {@link DataProcessingException}s).
+	 *
+	 * <p>The parsing parsing/writing won't stop (unless the error handler rethrows the {@link DataProcessingException} or manually stops the process).</p>
+	 *
+	 * @param processorErrorHandler the callback error handler with custom code to manage occurrences of {@link DataProcessingException}.
+	 *
+	 * @return this {@code CsvParserSettings} instance
+	 */
+	public CsvParserSettings setProcessorErrorHandler(ProcessorErrorHandler<? extends Context> processorErrorHandler) {
+		super.setProcessorErrorHandler(processorErrorHandler);
+		return this;
+	}
+
+	/**
+	 * Configures the parser/writer to limit the length of displayed contents being parsed/written in the exception message when an error occurs.
+	 *
+	 * <p>If set to {@code 0}, then no exceptions will include the content being manipulated in their attributes,
+	 * and the {@code "<omitted>"} string will appear in error messages as the parsed/written content.</p>
+	 *
+	 * <p>defaults to {@code -1} (no limit)</p>.
+	 *
+	 * @param errorContentLength maximum length of contents displayed in exception messages in case of errors while parsing/writing.
+	 *
+	 * @return this {@code CsvParserSettings} instance
+	 */
+	public CsvParserSettings setErrorContentLength(int errorContentLength) {
+		super.setErrorContentLength(errorContentLength);
+		return this;
+	}
+
+	/**
+	 * Configures the parser to skip bit values as whitespace.
+	 *
+	 * By default the parser/writer removes control characters and considers a whitespace any character where {@code character <= ' '} evaluates to
+	 * {@code true}. This includes bit values, i.e. {@code 0} (the \0 character) and {@code 1} which might
+	 * be produced by database dumps. Disabling this flag will prevent the parser/writer from discarding these characters
+	 * when {@link #getIgnoreLeadingWhitespaces()} or {@link #getIgnoreTrailingWhitespaces()} evaluate to {@code true}.
+	 *
+	 * <p>defaults to {@code true}</p>
+	 *
+	 * @param skipBitsAsWhitespace a flag indicating whether bit values (0 or 1) should be considered whitespace.
+	 *
+	 * @return this {@code CsvParserSettings} instance
+	 */
+	public final CsvParserSettings setSkipBitsAsWhitespace(boolean skipBitsAsWhitespace) {
+		super.setSkipBitsAsWhitespace(skipBitsAsWhitespace);
+		return this;
 	}
 }

--- a/src/main/java/com/univocity/parsers/csv/CsvWriterSettings.java
+++ b/src/main/java/com/univocity/parsers/csv/CsvWriterSettings.java
@@ -64,9 +64,12 @@ public class CsvWriterSettings extends CommonWriterSettings<CsvFormat> {
 	 * <p> By default, only values that contain a field separator are enclosed within quotes.
 	 *
 	 * @param quoteAllFields a flag indicating whether to enclose all fields within quotes
+	 *
+	 * @return this {@code CsvWriterSettings} instance
 	 */
-	public void setQuoteAllFields(boolean quoteAllFields) {
+	public CsvWriterSettings setQuoteAllFields(boolean quoteAllFields) {
 		this.quoteAllFields = quoteAllFields;
+		return this;
 	}
 
 	/**
@@ -90,9 +93,12 @@ public class CsvWriterSettings extends CommonWriterSettings<CsvFormat> {
 	 * to process escape sequences in unquoted values, the values will written as {@code [A""""B] and [C]}</p>
 	 *
 	 * @param escapeUnquotedValues a flag indicating whether escape sequences should be processed in unquoted values
+	 *
+	 * @return this {@code CsvWriterSettings} instance
 	 */
-	public void setEscapeUnquotedValues(boolean escapeUnquotedValues) {
+	public CsvWriterSettings setEscapeUnquotedValues(boolean escapeUnquotedValues) {
 		this.escapeUnquotedValues = escapeUnquotedValues;
+		return this;
 	}
 
 	/**
@@ -112,9 +118,12 @@ public class CsvWriterSettings extends CommonWriterSettings<CsvFormat> {
 	 * <p>This is disabled by default</p>
 	 *
 	 * @param isInputEscaped a flag indicating whether the input that will be written is already properly escaped.
+	 *
+	 * @return this {@code CsvWriterSettings} instance
 	 */
-	public final void setInputEscaped(boolean isInputEscaped) {
+	public final CsvWriterSettings setInputEscaped(boolean isInputEscaped) {
 		this.isInputEscaped = isInputEscaped;
+		return this;
 	}
 
 	/**
@@ -159,9 +168,12 @@ public class CsvWriterSettings extends CommonWriterSettings<CsvFormat> {
 	 * @param normalizeLineEndingsWithinQuotes flag indicating that line separator characters in quoted values should be
 	 *                                         considered 'normalized' and occurrences of {@link Format#getNormalizedNewline()}
 	 *                                         should be replaced by the sequence specified in {@link Format#getLineSeparator()}
+	 *
+	 * @return this {@code CsvWriterSettings} instance
 	 */
-	public void setNormalizeLineEndingsWithinQuotes(boolean normalizeLineEndingsWithinQuotes) {
+	public CsvWriterSettings setNormalizeLineEndingsWithinQuotes(boolean normalizeLineEndingsWithinQuotes) {
 		this.normalizeLineEndingsWithinQuotes = normalizeLineEndingsWithinQuotes;
+		return this;
 	}
 
 	/**
@@ -191,9 +203,12 @@ public class CsvWriterSettings extends CommonWriterSettings<CsvFormat> {
 	 *
 	 * @param quotationTriggers a list of characters that when present in a value to be written, will
 	 *                          force the output value to be enclosed in quotes.
+	 *
+	 * @return this {@code CsvWriterSettings} instance
 	 */
-	public void setQuotationTriggers(char... quotationTriggers) {
+	public CsvWriterSettings setQuotationTriggers(char... quotationTriggers) {
 		this.quotationTriggers = quotationTriggers == null ? new char[0] : quotationTriggers;
+		return this;
 	}
 
 	/**
@@ -244,9 +259,12 @@ public class CsvWriterSettings extends CommonWriterSettings<CsvFormat> {
 	 * but it will still be valid as the value does not contain line separators nor the delimiter character.
 	 *
 	 * @param quoteEscapingEnabled a flag indicating whether values containing quotes should be enclosed in quotes.
+	 *
+	 * @return this {@code CsvWriterSettings} instance
 	 */
-	public void setQuoteEscapingEnabled(boolean quoteEscapingEnabled) {
+	public CsvWriterSettings setQuoteEscapingEnabled(boolean quoteEscapingEnabled) {
 		this.quoteEscapingEnabled = quoteEscapingEnabled;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/com/univocity/parsers/tsv/TsvFormat.java
+++ b/src/main/java/com/univocity/parsers/tsv/TsvFormat.java
@@ -37,10 +37,14 @@ public class TsvFormat extends Format {
 
 	/**
 	 * Defines the character used for escaping special characters in TSV inputs: \t, \n, \r and \ . Defaults to '\\'
+	 *
 	 * @param escapeChar the escape character
+	 *
+	 * @return this {@code TsvFormat} instance
 	 */
-	public void setEscapeChar(char escapeChar) {
+	public TsvFormat setEscapeChar(char escapeChar) {
 		this.escapeChar = escapeChar;
+		return this;
 	}
 
 	/**
@@ -73,9 +77,12 @@ public class TsvFormat extends Format {
 	 * Defaults to {@code 't'}.
 	 *
 	 * @param escapedTabChar the character following the {@link #getEscapeChar()} that represents an escaped tab.
+	 *
+	 * @return this {@code TsvFormat} instance
 	 */
-	public void setEscapedTabChar(char escapedTabChar) {
+	public TsvFormat setEscapedTabChar(char escapedTabChar) {
 		this.escapedTabChar = escapedTabChar;
+		return this;
 	}
 
 	/**
@@ -85,6 +92,55 @@ public class TsvFormat extends Format {
 	 */
 	public boolean isEscapeChar(char ch) {
 		return this.escapeChar == ch;
+	}
+
+	/**
+	 * Defines the line separator sequence that should be used for parsing and writing.
+	 *
+	 * @param lineSeparator a sequence of 1 to 2 characters that identifies the end of a line
+	 *
+	 * @return this {@code TsvFormat} instance
+	 */
+	public TsvFormat setLineSeparator(String lineSeparator) {
+		super.setLineSeparator(lineSeparator);
+		return this;
+	}
+
+	/**
+	 * Defines the line separator sequence that should be used for parsing and writing.
+	 *
+	 * @param lineSeparator a sequence of 1 to 2 characters that identifies the end of a line
+	 *
+	 * @return this {@code TsvFormat} instance
+	 */
+	public TsvFormat setLineSeparator(char[] lineSeparator) {
+		super.setLineSeparator(lineSeparator);
+		return this;
+	}
+
+	/**
+	 * Sets the normalized newline character, which is automatically replaced by {@link Format#getLineSeparator} when reading/writing
+	 *
+	 * @param normalizedNewline a single character used to represent a line separator.
+	 *
+	 * @return this {@code TsvFormat} instance
+	 */
+	public TsvFormat setNormalizedNewline(char normalizedNewline) {
+		super.setNormalizedNewline(normalizedNewline);
+		return this;
+	}
+
+	/**
+	 * Defines the character that represents a line comment when found in the beginning of a line of text. Defaults to '#'
+	 * <p> Use '\0' to disable comment skipping.
+	 *
+	 * @param comment the comment character
+	 *
+	 * @return this {@code TsvFormat} instance
+	 */
+	public TsvFormat setComment(char comment) {
+		super.setComment(comment);
+		return this;
 	}
 
 	@Override

--- a/src/main/java/com/univocity/parsers/tsv/TsvParserSettings.java
+++ b/src/main/java/com/univocity/parsers/tsv/TsvParserSettings.java
@@ -16,6 +16,9 @@
 package com.univocity.parsers.tsv;
 
 import com.univocity.parsers.common.*;
+import com.univocity.parsers.annotations.Parsed;
+import com.univocity.parsers.annotations.Headers;
+import com.univocity.parsers.common.processor.*;
 
 import java.util.*;
 
@@ -71,9 +74,216 @@ public class TsvParserSettings extends CommonParserSettings<TsvFormat> {
 	 * not preceded by another escape character.
 	 *
 	 * @param lineJoiningEnabled a flag indicating whether or not to enable line joining.
+	 *
+	 * @return this {@code TsvParserSettings} instance
 	 */
-	public void setLineJoiningEnabled(boolean lineJoiningEnabled) {
+	public TsvParserSettings setLineJoiningEnabled(boolean lineJoiningEnabled) {
 		this.lineJoiningEnabled = lineJoiningEnabled;
+		return this;
+	}
+
+	/**
+	 * Sets the String representation of a null value (defaults to null)
+	 * <p>When reading, if the parser does not read any character from the input, the nullValue is used instead of an empty string
+	 * <p>When writing, if the writer has a null object to write to the output, the nullValue is used instead of an empty string
+	 *
+	 * @param emptyValue the String representation of a null value
+	 *
+	 * @return this {@code TsvParserSettings} instance
+	 */
+	public TsvParserSettings setNullValue(String emptyValue) {
+		super.setNullValue(emptyValue);
+		return this;
+	}
+
+	/**
+	 * Defines the maximum number of characters allowed for any given value being written/read. Used to avoid OutOfMemoryErrors (defaults to 4096).
+	 *
+	 * <p>To enable auto-expansion of the internal array, set this property to -1</p>
+	 *
+	 * @param maxCharsPerColumn The maximum number of characters allowed for any given value being written/read
+	 *
+	 * @return this {@code TsvParserSettings} instance
+	 */
+	public TsvParserSettings setMaxCharsPerColumn(int maxCharsPerColumn) {
+		super.setMaxCharsPerColumn(maxCharsPerColumn);
+		return this;
+	}
+
+	/**
+	 * Defines whether or not empty lines should be ignored (defaults to true)
+	 * <p>when reading, if the parser reads a line that is empty, it will be skipped.
+	 * <p>when writing, if the writer receives an empty or null row to write to the output, it will be ignored
+	 *
+	 * @param skipEmptyLines true if empty lines should be ignored, false otherwise
+	 *
+	 * @return this {@code TsvParserSettings} instance
+	 */
+	public TsvParserSettings setSkipEmptyLines(boolean skipEmptyLines) {
+		super.setSkipEmptyLines(skipEmptyLines);
+		return this;
+	}
+
+	/**
+	 * Defines whether or not trailing whitespaces from values being read/written should be skipped  (defaults to true)
+	 *
+	 * @param ignoreTrailingWhitespaces true if trailing whitespaces from values being read/written should be skipped, false otherwise
+	 *
+	 * @return this {@code TsvParserSettings} instance
+	 */
+	public TsvParserSettings setIgnoreTrailingWhitespaces(boolean ignoreTrailingWhitespaces) {
+		super.setIgnoreTrailingWhitespaces(ignoreTrailingWhitespaces);
+		return this;
+	}
+
+	/**
+	 * Defines whether or not leading whitespaces from values being read/written should be skipped  (defaults to true)
+	 *
+	 * @param ignoreLeadingWhitespaces true if leading whitespaces from values being read/written should be skipped, false otherwise
+	 *
+	 * @return this {@code TsvParserSettings} instance
+	 */
+	public TsvParserSettings setIgnoreLeadingWhitespaces(boolean ignoreLeadingWhitespaces) {
+		super.setIgnoreLeadingWhitespaces(ignoreLeadingWhitespaces);
+		return this;
+	}
+
+	/**
+	 * Defines the field names in the input/output, in the sequence they occur (defaults to null).
+	 * <p>when reading, the given header names will be used to refer to each column irrespective of whether or not the input contains a header row
+	 * <p>when writing, the given header names will be used to refer to each column and can be used for writing the header row
+	 *
+	 * @param headers the field name sequence associated with each column in the input/output.
+	 *
+	 * @return this {@code TsvParserSettings} instance
+	 */
+	public TsvParserSettings setHeaders(String... headers) {
+		super.setHeaders(headers);
+		return this;
+	}
+
+	/**
+	 * Defines the field names in the input/output derived from a given class with {@link Parsed} annotated attributes/methods.
+	 * <p>when reading, the given header names will be used to refer to each column irrespective of whether or not the input contains a header row
+	 * <p>when writing, the given header names will be used to refer to each column and can be used for writing the header row
+	 *
+	 * @param headerSourceClass the class from which the headers have been derived.
+	 * @param headers           the field name sequence associated with each column in the input/output.
+	 *
+	 * @return this {@code TsvParserSettings} instance
+	 */
+	public TsvParserSettings setHeadersDerivedFromClass(Class<?> headerSourceClass, String... headers) {
+		super.setHeadersDerivedFromClass(headerSourceClass, headers);
+		return this;
+	}
+
+	/**
+	 * Defines a hard limit of how many columns a record can have (defaults to 512).
+	 * You need this to avoid OutOfMemory errors in case of inputs that might be inconsistent with the format you are dealing with.
+	 *
+	 * @param maxColumns The maximum number of columns a record can have.
+	 *
+	 * @return this {@code TsvParserSettings} instance
+	 */
+	public TsvParserSettings setMaxColumns(int maxColumns) {
+		super.setMaxColumns(maxColumns);
+		return this;
+	}
+
+	/**
+	 * Defines the format of the file to be parsed/written (returns the format's defaults).
+	 *
+	 * @param format The format of the file to be parsed/written
+	 *
+	 * @return this {@code TsvParserSettings} instance
+	 */
+	public TsvParserSettings setFormat(TsvFormat format) {
+		super.setFormat(format);
+		return this;
+	}
+
+	/**
+	 * Indicates whether this settings object can automatically derive configuration options. This is used, for example, to define the headers when the user
+	 * provides a {@link BeanWriterProcessor} where the bean class contains a {@link Headers} annotation, or to enable header extraction when the bean class of a
+	 * {@link BeanProcessor} has attributes mapping to header names.
+	 *
+	 * @param autoConfigurationEnabled a flag to turn the automatic configuration feature on/off.
+	 *
+	 * @return this {@code TsvParserSettings} instance
+	 */
+	public final TsvParserSettings setAutoConfigurationEnabled(boolean autoConfigurationEnabled) {
+		super.setAutoConfigurationEnabled(autoConfigurationEnabled);
+		return this;
+	}
+
+	/**
+	 * Defines a custom error handler to capture and handle errors that might happen while processing records with a {@link RowProcessor}
+	 * or a {@link RowWriterProcessor} (i.e. non-fatal {@link DataProcessingException}s).
+	 *
+	 * <p>The parsing parsing/writing won't stop (unless the error handler rethrows the {@link DataProcessingException} or manually stops the process).</p>
+	 *
+	 * @param rowProcessorErrorHandler the callback error handler with custom code to manage occurrences of {@link DataProcessingException}.
+	 *
+	 * @return this {@code TsvParserSettings} instance
+	 *
+	 * @deprecated Use the {@link #setProcessorErrorHandler(ProcessorErrorHandler)} method as it allows format-specific error handlers to be built to work with different implementations of {@link Context}.
+	 * Implementations based on {@link RowProcessorErrorHandler} allow only parsers who provide a {@link ParsingContext} to be used.
+	 */
+	@Deprecated
+	public TsvParserSettings setRowProcessorErrorHandler(RowProcessorErrorHandler rowProcessorErrorHandler) {
+		super.setRowProcessorErrorHandler(rowProcessorErrorHandler);
+		return this;
+	}
+
+	/**
+	 * Defines a custom error handler to capture and handle errors that might happen while processing records with a {@link com.univocity.parsers.common.processor.core.Processor}
+	 * or a {@link RowWriterProcessor} (i.e. non-fatal {@link DataProcessingException}s).
+	 *
+	 * <p>The parsing parsing/writing won't stop (unless the error handler rethrows the {@link DataProcessingException} or manually stops the process).</p>
+	 *
+	 * @param processorErrorHandler the callback error handler with custom code to manage occurrences of {@link DataProcessingException}.
+	 *
+	 * @return this {@code TsvParserSettings} instance
+	 */
+	public TsvParserSettings setProcessorErrorHandler(ProcessorErrorHandler<? extends Context> processorErrorHandler) {
+		super.setProcessorErrorHandler(processorErrorHandler);
+		return this;
+	}
+
+	/**
+	 * Configures the parser/writer to limit the length of displayed contents being parsed/written in the exception message when an error occurs.
+	 *
+	 * <p>If set to {@code 0}, then no exceptions will include the content being manipulated in their attributes,
+	 * and the {@code "<omitted>"} string will appear in error messages as the parsed/written content.</p>
+	 *
+	 * <p>defaults to {@code -1} (no limit)</p>.
+	 *
+	 * @param errorContentLength maximum length of contents displayed in exception messages in case of errors while parsing/writing.
+	 *
+	 * @return this {@code TsvParserSettings} instance
+	 */
+	public TsvParserSettings setErrorContentLength(int errorContentLength) {
+		super.setErrorContentLength(errorContentLength);
+		return this;
+	}
+
+	/**
+	 * Configures the parser to skip bit values as whitespace.
+	 *
+	 * By default the parser/writer removes control characters and considers a whitespace any character where {@code character <= ' '} evaluates to
+	 * {@code true}. This includes bit values, i.e. {@code 0} (the \0 character) and {@code 1} which might
+	 * be produced by database dumps. Disabling this flag will prevent the parser/writer from discarding these characters
+	 * when {@link #getIgnoreLeadingWhitespaces()} or {@link #getIgnoreTrailingWhitespaces()} evaluate to {@code true}.
+	 *
+	 * <p>defaults to {@code true}</p>
+	 *
+	 * @param skipBitsAsWhitespace a flag indicating whether bit values (0 or 1) should be considered whitespace.
+	 *
+	 * @return this {@code TsvParserSettings} instance
+	 */
+	public final TsvParserSettings setSkipBitsAsWhitespace(boolean skipBitsAsWhitespace) {
+		super.setSkipBitsAsWhitespace(skipBitsAsWhitespace);
+		return this;
 	}
 
 	/**

--- a/src/main/java/com/univocity/parsers/tsv/TsvWriterSettings.java
+++ b/src/main/java/com/univocity/parsers/tsv/TsvWriterSettings.java
@@ -78,9 +78,12 @@ public class TsvWriterSettings extends CommonWriterSettings<TsvFormat> {
 	 * characters will be written as: {@code '\'+'\n'} and {@code '\'+'\r'}.
 	 *
 	 * @param lineJoiningEnabled a flag indicating whether or not to enable line joining.
+	 *
+	 * @return this {@code TsvParserSettings} instance
 	 */
-	public void setLineJoiningEnabled(boolean lineJoiningEnabled) {
+	public TsvWriterSettings setLineJoiningEnabled(boolean lineJoiningEnabled) {
 		this.lineJoiningEnabled = lineJoiningEnabled;
+		return this;
 	}
 
 	/**


### PR DESCRIPTION
First of all, thank you for writing and maintaining this excellent library, it's been working flawlessly for us :)

I'm currently in the process of integrating the UniVocity CSV parser into one of our ETL jobs. Here's the code I came up with:

```java
CsvFormat csvFormat = new CsvFormat();
csvFormat.setLineSeparator("/");
csvFormat.setDelimiter(";");

CsvParserSettings csvParserSettings = new CsvParserSettings();
csvParserSettings.setFormat(csvFormat);

CsvParser csvParser = new CsvParser(csvParserSettings);
```

Whew, that's a lot of code. If all these various setter methods returned `this`, it would have been a lot more convenient to construct a parser instance:

```java
CsvParser csvParser = new CsvParser(
  new CsvParserSettings().setFormat(
    new CsvFormat()
      .setLineSeparator("/")
      .setDelimiter(";")
  )
)
```

Ok, so that only saves one line of code (including newlines) 😅 but I would argue it's 1) easier to read, and 2) uses 2 fewer local variables. Plus it could collapse down to fewer lines and only sacrifice readability a little bit:

```java
CsvParser csvParser = new CsvParser(
  new CsvParserSettings().setFormat(
    new CsvFormat().setLineSeparator("/").setDelimiter(";")
  )
)
```

Thoughts?