### PR TITLE
parseLine() is throwing ClassCastException when using look ahead

### DIFF
--- a/src/main/java/com/univocity/parsers/common/AbstractParser.java
+++ b/src/main/java/com/univocity/parsers/common/AbstractParser.java
@@ -655,7 +655,11 @@ public abstract class AbstractParser<T extends CommonParserSettings<?>> {
 		if (context == null || context.isStopped()) {
 			beginParsing(lineReader);
 		} else {
-			((DefaultCharInputReader) input).reloadBuffer();
+		  if(input instanceof DefaultCharInputReader) {
+		    ((DefaultCharInputReader) input).reloadBuffer();
+		  }else if(input instanceof LookaheadCharInputReader) {
+        ((LookaheadCharInputReader) input).reloadBuffer();
+      }
 		}
 		try {
 			while (!context.isStopped()) {

--- a/src/main/java/com/univocity/parsers/common/input/AbstractCharInputReader.java
+++ b/src/main/java/com/univocity/parsers/common/input/AbstractCharInputReader.java
@@ -471,7 +471,7 @@ public abstract class AbstractCharInputReader implements CharInputReader {
 
 		int pos = this.i - 1;
 		int len = i - this.i;
-		if (len > maxLength) { //validating before trailing whitespace handling so this behaves as an appender.
+		if (maxLength != -1 && len > maxLength) { //validating before trailing whitespace handling so this behaves as an appender.
 			return null;
 		}
 
@@ -541,7 +541,7 @@ public abstract class AbstractCharInputReader implements CharInputReader {
 
 		int pos = this.i;
 		int len = i - this.i;
-		if (len > maxLength) { //validating before trailing whitespace handling so this behaves as an appender.
+		if (maxLength != -1 && len > maxLength) { //validating before trailing whitespace handling so this behaves as an appender.
 			return null;
 		}
 

--- a/src/main/java/com/univocity/parsers/common/input/LookaheadCharInputReader.java
+++ b/src/main/java/com/univocity/parsers/common/input/LookaheadCharInputReader.java
@@ -258,4 +258,10 @@ public class LookaheadCharInputReader implements CharInputReader {
 	public int lastIndexOf(char ch) {
 		return reader.lastIndexOf(ch);
 	}
+
+  public void reloadBuffer () {
+    if(reader instanceof DefaultCharInputReader) {
+      ((DefaultCharInputReader) reader).reloadBuffer ();
+    }
+  }
 }

--- a/src/main/java/com/univocity/parsers/fixed/FixedWidthParser.java
+++ b/src/main/java/com/univocity/parsers/fixed/FixedWidthParser.java
@@ -116,9 +116,9 @@ public class FixedWidthParser extends AbstractParser<FixedWidthParserSettings> {
 					return lookupFormat != null ? NormalizedString.toArray(lookupFormat.fieldNames) : super.headers();
 				}
 
-				public Record toRecord(String[] row){
-					if(lookupFormat != null){
-						if(lookupFormat.context == null){
+				public Record toRecord(String[] row) {
+					if (lookupFormat != null) {
+						if (lookupFormat.context == null) {
 							lookupFormat.initializeLookupContext(context, lookupFormat.fieldNames);
 						}
 						return lookupFormat.context.toRecord(row);
@@ -217,7 +217,7 @@ public class FixedWidthParser extends AbstractParser<FixedWidthParserSettings> {
 			}
 			final boolean lastFieldOfRecord = (i + 1 >= lengths.length);
 
-			if(ignorePadding) {
+			if (ignorePadding) {
 				skipPadding(lastFieldOfRecord);
 			}
 
@@ -262,21 +262,21 @@ public class FixedWidthParser extends AbstractParser<FixedWidthParserSettings> {
 		}
 	}
 
-  private void skipPadding (boolean lastFieldOfRecord) {
-    while (ch == padding && length-- > 0) {
-      if (!lastFieldOfRecord || length > 0) {
-        ch = input.nextChar ();
-      }
-    }
-  }
+	private void skipPadding(boolean lastFieldOfRecord) {
+		while (ch == padding && length-- > 0) {
+			if (!lastFieldOfRecord || length > 0) {
+				ch = input.nextChar();
+			}
+		}
+	}
 
-  private void skipWhitespace (boolean lastFieldOfRecord) {
-    while ((ch <= ' ' && whitespaceRangeStart < ch || ch == padding) && length-- > 0) {
-      if (!lastFieldOfRecord || length > 0) {
-        ch = input.nextChar ();
-      }
-    }
-  }
+	private void skipWhitespace(boolean lastFieldOfRecord) {
+		while ((ch <= ' ' && whitespaceRangeStart < ch || ch == padding) && length-- > 0) {
+			if (!lastFieldOfRecord || length > 0) {
+				ch = input.nextChar();
+			}
+		}
+	}
 
 	private void readValueUntilNewLine(boolean ignorePadding) {
 		if (ignoreTrailingWhitespace) {
@@ -285,7 +285,7 @@ public class FixedWidthParser extends AbstractParser<FixedWidthParserSettings> {
 					output.appender.appendIgnoringWhitespace(ch);
 					ch = input.nextChar();
 				}
-			} else if(ignorePadding){
+			} else if (ignorePadding) {
 				while (length-- > 0 && ch != newLine) {
 					output.appender.appendIgnoringWhitespaceAndPadding(ch, padding);
 					ch = input.nextChar();
@@ -303,7 +303,7 @@ public class FixedWidthParser extends AbstractParser<FixedWidthParserSettings> {
 					output.appender.append(ch);
 					ch = input.nextChar();
 				}
-			} else if(ignorePadding) {
+			} else if (ignorePadding) {
 				while (length-- > 0 && ch != newLine) {
 					output.appender.appendIgnoringPadding(ch, padding);
 					ch = input.nextChar();
@@ -325,7 +325,7 @@ public class FixedWidthParser extends AbstractParser<FixedWidthParserSettings> {
 				while (length-- > 0) {
 					output.appender.appendIgnoringWhitespace(ch = input.nextChar());
 				}
-			} else if(ignorePadding){
+			} else if (ignorePadding) {
 				output.appender.appendIgnoringWhitespaceAndPadding(ch, padding);
 				while (length-- > 0) {
 					output.appender.appendIgnoringWhitespaceAndPadding(ch = input.nextChar(), padding);
@@ -342,7 +342,7 @@ public class FixedWidthParser extends AbstractParser<FixedWidthParserSettings> {
 				while (length-- > 0) {
 					output.appender.append(ch = input.nextChar());
 				}
-			} else if(ignorePadding){
+			} else if (ignorePadding) {
 				output.appender.appendIgnoringPadding(ch, padding);
 				while (length-- > 0) {
 					output.appender.appendIgnoringPadding(ch = input.nextChar(), padding);

--- a/src/main/java/com/univocity/parsers/fixed/FixedWidthParser.java
+++ b/src/main/java/com/univocity/parsers/fixed/FixedWidthParser.java
@@ -215,13 +215,14 @@ public class FixedWidthParser extends AbstractParser<FixedWidthParserSettings> {
 			if (alignments != null) {
 				alignment = alignments[i];
 			}
+			final boolean lastFieldOfRecord = (i + 1 >= lengths.length);
 
 			if(ignorePadding) {
-				skipPadding();
+				skipPadding(lastFieldOfRecord);
 			}
 
 			if (ignoreLeadingWhitespace) {
-				skipWhitespace();
+				skipWhitespace(lastFieldOfRecord);
 			}
 
 			if (recordEndsOnNewLine) {
@@ -233,7 +234,7 @@ public class FixedWidthParser extends AbstractParser<FixedWidthParserSettings> {
 				}
 			} else if (length > 0) {
 				readValue(ignorePadding);
-				if (i + 1 < lengths.length) {
+				if (!lastFieldOfRecord) {
 					ch = input.nextChar();
 				}
 			}
@@ -261,17 +262,21 @@ public class FixedWidthParser extends AbstractParser<FixedWidthParserSettings> {
 		}
 	}
 
-	private void skipPadding() {
-		while (ch == padding && length-- > 0) {
-			ch = input.nextChar();
-		}
-	}
+  private void skipPadding (boolean lastFieldOfRecord) {
+    while (ch == padding && length-- > 0) {
+      if (!lastFieldOfRecord || length > 0) {
+        ch = input.nextChar ();
+      }
+    }
+  }
 
-	private void skipWhitespace() {
-		while ((ch <= ' ' && whitespaceRangeStart < ch || ch == padding) && length-- > 0) {
-			ch = input.nextChar();
-		}
-	}
+  private void skipWhitespace (boolean lastFieldOfRecord) {
+    while ((ch <= ' ' && whitespaceRangeStart < ch || ch == padding) && length-- > 0) {
+      if (!lastFieldOfRecord || length > 0) {
+        ch = input.nextChar ();
+      }
+    }
+  }
 
 	private void readValueUntilNewLine(boolean ignorePadding) {
 		if (ignoreTrailingWhitespace) {

--- a/src/test/java/com/univocity/parsers/fixed/FixedWidthParserTest.java
+++ b/src/test/java/com/univocity/parsers/fixed/FixedWidthParserTest.java
@@ -322,4 +322,29 @@ public class FixedWidthParserTest extends ParserTestCase {
 		assertEquals(line[1], "1234");
 
 	}
+
+	 @Test
+	  public void testSingleLineParsingWithLookAhead() {
+	    FixedWidthFields fields1 = new FixedWidthFields();
+	    fields1.addField(1).addField(5);
+
+	    FixedWidthFields fields2 = new FixedWidthFields();
+	    fields2.addField(1).addField(2).addField(3);
+
+	    FixedWidthParserSettings s = new FixedWidthParserSettings();
+	    s.addFormatForLookahead ("1", fields1);
+	    s.addFormatForLookahead ("2", fields2);
+	    FixedWidthParser p = new FixedWidthParser(s);
+
+	    String[] line1 = p.parseLine("1ABCDE");
+	    assertEquals(line1.length, 2);
+	    assertEquals(line1[0], "1");
+	    assertEquals(line1[1], "ABCDE");
+
+	    String[] line2 = p.parseLine("2ABCDE");
+      assertEquals(line2.length, 3);
+      assertEquals(line2[0], "2");
+      assertEquals(line2[1], "AB");
+      assertEquals(line2[2], "CDE");
+	  }
 }

--- a/src/test/java/com/univocity/parsers/fixed/FixedWidthParserTest.java
+++ b/src/test/java/com/univocity/parsers/fixed/FixedWidthParserTest.java
@@ -211,6 +211,30 @@ public class FixedWidthParserTest extends ParserTestCase {
 		assertEquals(data[2], "kl");
 	}
 
+  @Test
+  public void testParsingWithoutRecordBreaksButTrailingSpaces () {
+    int[] length = new int[] {2, 2, 2, 2};
+    FixedWidthFields lengths = new FixedWidthFields (length);
+    FixedWidthParserSettings settings = new FixedWidthParserSettings (lengths);
+
+    FixedWidthParser parser = new FixedWidthParser (settings);
+    parser.beginParsing (new StringReader ("abcdef  ghijkl  "));
+
+    String[] data;
+
+    data = parser.parseNext ();
+    assertEquals (data[0], "ab");
+    assertEquals (data[1], "cd");
+    assertEquals (data[2], "ef");
+    assertEquals (data[3], null);
+
+    data = parser.parseNext ();
+    assertEquals (data[0], "gh");
+    assertEquals (data[1], "ij");
+    assertEquals (data[2], "kl");
+    assertEquals (data[3], null);
+  }
+
 	@Test
 	public void testBitsAreNotDiscardedWhenParsing() {
 		FixedWidthFields lengths = new FixedWidthFields(3, 3);

--- a/src/test/java/com/univocity/parsers/fixed/FixedWidthParserTest.java
+++ b/src/test/java/com/univocity/parsers/fixed/FixedWidthParserTest.java
@@ -211,29 +211,29 @@ public class FixedWidthParserTest extends ParserTestCase {
 		assertEquals(data[2], "kl");
 	}
 
-  @Test
-  public void testParsingWithoutRecordBreaksButTrailingSpaces () {
-    int[] length = new int[] {2, 2, 2, 2};
-    FixedWidthFields lengths = new FixedWidthFields (length);
-    FixedWidthParserSettings settings = new FixedWidthParserSettings (lengths);
+	@Test
+	public void testParsingWithoutRecordBreaksButTrailingSpaces() {
+		int[] length = new int[]{2, 2, 2, 2};
+		FixedWidthFields lengths = new FixedWidthFields(length);
+		FixedWidthParserSettings settings = new FixedWidthParserSettings(lengths);
 
-    FixedWidthParser parser = new FixedWidthParser (settings);
-    parser.beginParsing (new StringReader ("abcdef  ghijkl  "));
+		FixedWidthParser parser = new FixedWidthParser(settings);
+		parser.beginParsing(new StringReader("abcdef  ghijkl  "));
 
-    String[] data;
+		String[] data;
 
-    data = parser.parseNext ();
-    assertEquals (data[0], "ab");
-    assertEquals (data[1], "cd");
-    assertEquals (data[2], "ef");
-    assertEquals (data[3], null);
+		data = parser.parseNext();
+		assertEquals(data[0], "ab");
+		assertEquals(data[1], "cd");
+		assertEquals(data[2], "ef");
+		assertEquals(data[3], null);
 
-    data = parser.parseNext ();
-    assertEquals (data[0], "gh");
-    assertEquals (data[1], "ij");
-    assertEquals (data[2], "kl");
-    assertEquals (data[3], null);
-  }
+		data = parser.parseNext();
+		assertEquals(data[0], "gh");
+		assertEquals(data[1], "ij");
+		assertEquals(data[2], "kl");
+		assertEquals(data[3], null);
+	}
 
 	@Test
 	public void testBitsAreNotDiscardedWhenParsing() {

--- a/src/test/java/com/univocity/parsers/issues/github/Github_337.java
+++ b/src/test/java/com/univocity/parsers/issues/github/Github_337.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright 2019 Univocity Software Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+package com.univocity.parsers.issues.github;
+
+
+import com.univocity.parsers.csv.*;
+import org.testng.annotations.*;
+
+import static org.testng.Assert.*;
+
+/**
+ * From: https://github.com/univocity/univocity-parsers/issues/337
+ *
+ * @author Univocity Software Pty Ltd - <a href="mailto:dev@univocity.com">dev@univocity.com</a>
+ */
+public class Github_337 {
+
+	@DataProvider
+	public Object[][] maxProvider() {
+		return new Object[][]{
+				{-1},
+				{1000},
+		};
+	}
+
+	@Test(dataProvider = "maxProvider")
+	public void testInconsistentParsing(int max) {
+
+		CsvParserSettings settings = new CsvParserSettings();
+		// we handle headers by ourselves
+		settings.setHeaderExtractionEnabled(false);
+		settings.setReadInputOnSeparateThread(false);
+		settings.setInputBufferSize(1024 * 1024);
+		// Assume 1st line EOL indicates what the others will have as well
+		settings.setLineSeparatorDetectionEnabled(true);
+		settings.setUnescapedQuoteHandling(UnescapedQuoteHandling.RAISE_ERROR);
+		settings.setMaxCharsPerColumn(max);
+		CsvFormat format = settings.getFormat();
+		format.setDelimiter(',');
+		format.setCharToEscapeQuoteEscaping('\\');
+
+		String input = "18/01/2015,\"c_Pg,%W\\\",Ci\\tHpSDgA,\"!DLBpRjdV,\",306,5,!MuhlLqK,SPC_nTA%uZG$,SSC1_Vy\\K\\HEw,SSC2_ktmaDk!b,SSC3_#pbNlkTf,SSC4_a@J\\%dDL,PC_UfKoRZsI,PSC2_oHyn\\hMn,\"PSC3_\\QvO#,iy\",PSC4_x_KwV\\Z?,PSC5_!W\\ZI#l!,61.24,4,5,7,3,False\n";
+		String[] result = new CsvParser(settings).parseLine(input);
+		assertEquals(result.length, 23);
+
+		assertEquals(result[0], "18/01/2015");
+		assertEquals(result[1], "c_Pg,%W\\");
+		assertEquals(result[2], "Ci\\tHpSDgA");
+		assertEquals(result[3], "!DLBpRjdV,");
+		assertEquals(result[4], "306");
+		assertEquals(result[5], "5");
+		assertEquals(result[6], "!MuhlLqK");
+		assertEquals(result[7], "SPC_nTA%uZG$");
+		assertEquals(result[8], "SSC1_Vy\\K\\HEw");
+		assertEquals(result[9], "SSC2_ktmaDk!b");
+		assertEquals(result[10], "SSC3_#pbNlkTf");
+		assertEquals(result[11], "SSC4_a@J\\%dDL");
+		assertEquals(result[12], "PC_UfKoRZsI");
+		assertEquals(result[13], "PSC2_oHyn\\hMn");
+		assertEquals(result[14], "PSC3_\\QvO#,iy");
+		assertEquals(result[15], "PSC4_x_KwV\\Z?");
+		assertEquals(result[16], "PSC5_!W\\ZI#l!");
+		assertEquals(result[17], "61.24");
+		assertEquals(result[18], "4");
+		assertEquals(result[19], "5");
+		assertEquals(result[20], "7");
+		assertEquals(result[21], "3");
+		assertEquals(result[22], "False");
+	}
+}


### PR DESCRIPTION
When calling parseLine() on FixedWidthParser and lookahead is configured for that parser a ClassCastException will be thrown due to the underlying CharInputReader is casted to DefaultCharInputReader instead of LookaheadCharInputReader.