### PR TITLE
parseLine() is throwing ClassCastException when using lookahead

### DIFF
--- a/src/main/java/com/univocity/parsers/common/AbstractParser.java
+++ b/src/main/java/com/univocity/parsers/common/AbstractParser.java
@@ -655,7 +655,11 @@ public abstract class AbstractParser<T extends CommonParserSettings<?>> {
 		if (context == null || context.isStopped()) {
 			beginParsing(lineReader);
 		} else {
-			((DefaultCharInputReader) input).reloadBuffer();
+		  if(input instanceof DefaultCharInputReader) {
+		    ((DefaultCharInputReader) input).reloadBuffer();
+		  }else if(input instanceof LookaheadCharInputReader) {
+        ((LookaheadCharInputReader) input).reloadBuffer();
+      }
 		}
 		try {
 			while (!context.isStopped()) {

--- a/src/main/java/com/univocity/parsers/common/input/LookaheadCharInputReader.java
+++ b/src/main/java/com/univocity/parsers/common/input/LookaheadCharInputReader.java
@@ -258,4 +258,10 @@ public class LookaheadCharInputReader implements CharInputReader {
 	public int lastIndexOf(char ch) {
 		return reader.lastIndexOf(ch);
 	}
+
+  public void reloadBuffer () {
+    if(reader instanceof DefaultCharInputReader) {
+      ((DefaultCharInputReader) reader).reloadBuffer ();
+    }
+  }
 }

--- a/src/test/java/com/univocity/parsers/fixed/FixedWidthParserTest.java
+++ b/src/test/java/com/univocity/parsers/fixed/FixedWidthParserTest.java
@@ -322,4 +322,29 @@ public class FixedWidthParserTest extends ParserTestCase {
 		assertEquals(line[1], "1234");
 
 	}
+
+	 @Test
+	  public void testSingleLineParsingWithLookAhead() {
+	    FixedWidthFields fields1 = new FixedWidthFields();
+	    fields1.addField(1).addField(5);
+
+	    FixedWidthFields fields2 = new FixedWidthFields();
+	    fields2.addField(1).addField(2).addField(3);
+
+	    FixedWidthParserSettings s = new FixedWidthParserSettings();
+	    s.addFormatForLookahead ("1", fields1);
+	    s.addFormatForLookahead ("2", fields2);
+	    FixedWidthParser p = new FixedWidthParser(s);
+
+	    String[] line1 = p.parseLine("1ABCDE");
+	    assertEquals(line1.length, 2);
+	    assertEquals(line1[0], "1");
+	    assertEquals(line1[1], "ABCDE");
+
+	    String[] line2 = p.parseLine("2ABCDE");
+      assertEquals(line2.length, 3);
+      assertEquals(line2[0], "2");
+      assertEquals(line2[1], "AB");
+      assertEquals(line2[2], "CDE");
+	  }
 }


### PR DESCRIPTION
When calling parseLine() on FixedWidthParser and lookahead is configured for that parser a ClassCastException will be thrown due to the underlying CharInputReader is casted to DefaultCharInputReader instead of LookaheadCharInputReader.