### PR TITLE
Wrong index in fillOutputRow() causing ArrayIndexOutOfBoundsException

### DIFF
--- a/src/main/java/com/univocity/parsers/common/AbstractWriter.java
+++ b/src/main/java/com/univocity/parsers/common/AbstractWriter.java
@@ -910,7 +910,7 @@ public abstract class AbstractWriter<S extends CommonWriterSettings<?>> {
 		}
 		if (indexesToWrite.length < row.length) {
 			for (int i = 0; i < indexesToWrite.length; i++) {
-				outputRow[indexesToWrite[i]] = row[indexesToWrite[i]];
+				outputRow[i] = row[indexesToWrite[i]];
 			}
 		} else {
 			for (int i = 0; i < row.length && i < indexesToWrite.length; i++) {

--- a/src/test/java/com/univocity/parsers/common/AbstractWriterTest.java
+++ b/src/test/java/com/univocity/parsers/common/AbstractWriterTest.java
@@ -121,6 +121,26 @@ public class AbstractWriterTest extends ParserTestCase {
 	}
 
 	@Test
+	public void testSelectFields() {
+		StringWriter output = new StringWriter();
+
+		CsvWriterSettings settings = new CsvWriterSettings();
+		settings.setHeaderWritingEnabled(true);
+		settings.setColumnReorderingEnabled(true);
+		settings.setHeaders("A", "B", "C");
+		settings.selectFields("A", "C");
+
+		CsvWriter writer = new CsvWriter(output, settings);
+		writer.writeRow("V1", "V2", "V3");
+		writer.writeRow("V1", "V2", "V3");
+		writer.writeRow("V1", "V2", "V3");
+
+		writer.close();
+
+		assertEquals(output.toString(), "A,C\nV1,V3\nV1,V3\nV1,V3\n");
+	}
+
+	@Test
 	public void testExcludeFields() {
 		StringWriter output = new StringWriter();
 

--- a/src/test/java/com/univocity/parsers/common/AbstractWriterTest.java
+++ b/src/test/java/com/univocity/parsers/common/AbstractWriterTest.java
@@ -119,4 +119,24 @@ public class AbstractWriterTest extends ParserTestCase {
 
 		assertEquals(output.toString(), "A,B,C,D,E,F\n,,,,,\nV1,V2,V3,,,\nV1,V2,V3,4,5,\nV1,V2,V3,4,5,6\n");
 	}
+
+	@Test
+	public void testExcludeFields() {
+		StringWriter output = new StringWriter();
+
+		CsvWriterSettings settings = new CsvWriterSettings();
+		settings.setHeaderWritingEnabled(true);
+		settings.setColumnReorderingEnabled(true);
+		settings.setHeaders("A", "B", "C");
+		settings.excludeFields("B");
+
+		CsvWriter writer = new CsvWriter(output, settings);
+		writer.writeRow("V1", "V2", "V3");
+		writer.writeRow("V1", "V2", "V3");
+		writer.writeRow("V1", "V2", "V3");
+
+		writer.close();
+
+		assertEquals(output.toString(), "A,C\nV1,V3\nV1,V3\nV1,V3\n");
+	}
 }


### PR DESCRIPTION
When using setColumnReorderingEnabled() in CSV settings, an ArrayIndexOutOfBoundsException is thrown when excluding (or selecting headers that results in the exclusion of) specific headers. 

This was the result of the index being used to set values in outputRow coming from the indices of the actual selected headers, rather than the standard ordering of the loop.

I've included tests for columnReorderingEnabled() with excludeFields() and selectFields().