### PR TITLE
Fix NPE in EnumConversion

### DIFF
--- a/src/main/java/com/univocity/parsers/conversions/EnumConversion.java
+++ b/src/main/java/com/univocity/parsers/conversions/EnumConversion.java
@@ -250,7 +250,7 @@ public class EnumConversion<T extends Enum<T>> extends ObjectConversion<T> {
 		}
 
 		DataProcessingException exception = null;
-		if (customEnumMethod.getParameterTypes().length == 1) {
+		if (customEnumMethod != null && customEnumMethod.getParameterTypes().length == 1) {
 			try {
 				T out = (T) customEnumMethod.invoke(null, input);
 				return out;


### PR DESCRIPTION
Hi!

There is an NPE in the `EnumConversion#fromString(...)` in case there's no `CUSTOM_METHOD` selector (e.g. we are using a `CUSTOM_FIELD` instead) and we parse a row containing an invalid value. It prevents one from getting an expected `DataProcessingException` and handling it accordingly with a registered `ProcessorErrorHandler`.

Thank you for such a wonderful open-source product!

Cheers,
Mark