### PR TITLE
Fixed the repeatable conversions initialization in the DefaultConversionProcessor

### DIFF
--- a/src/main/java/com/univocity/parsers/common/DefaultConversionProcessor.java
+++ b/src/main/java/com/univocity/parsers/common/DefaultConversionProcessor.java
@@ -69,7 +69,6 @@ public abstract class DefaultConversionProcessor implements ConversionProcessor 
 
 		this.fieldIndexes = null;
 		this.fieldsReordered = false;
-		this.conversionsInitialized = false;
 
 		String[] contextHeaders = context == null ? null : context.headers();
 		if (contextHeaders != null && contextHeaders.length > 0) {


### PR DESCRIPTION
It is an obvious typo and it leads to a substantial performance degradation on big input files.

Cheers,
Mark.