### PR TITLE
Adds "com.googlecode.openbeans" as an optional OSGi dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,12 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>2.5.3</version>
+				<version>5.1.1</version>
+				<configuration>
+					<instructions>
+						<Import-Package>com.googlecode.openbeans;resolution:=optional,*</Import-Package>
+					</instructions>
+				</configuration>
 				<executions>
 					<execution>
 						<id>bundle-manifest</id>


### PR DESCRIPTION
Currently the openbeans implementation will never be used in an
OSGi environment due to a lack of "Import-Package" entry in the
manifest. Adding an optional entry to the OSGi manifest allows
consumers to chose whether to use it or not by installing the
necessary bundle in their OSGi runtime.

Signed-off-by: Mat Booth <mat.booth@redhat.com>