### PR TITLE
Issue394: Code to handle where all the lines should be treated as actual data including #

### DIFF
--- a/src/main/java/com/univocity/parsers/common/AbstractParser.java
+++ b/src/main/java/com/univocity/parsers/common/AbstractParser.java
@@ -74,6 +74,8 @@ public abstract class AbstractParser<T extends CommonParserSettings<?>> {
 	protected boolean ignoreTrailingWhitespace;
 	protected boolean ignoreLeadingWhitespace;
 
+	private final boolean commentLineCheck;
+
 	/**
 	 * All parsers must support, at the very least, the settings provided by {@link CommonParserSettings}. The AbstractParser requires its configuration to be
 	 * properly initialized.
@@ -96,6 +98,7 @@ public abstract class AbstractParser<T extends CommonParserSettings<?>> {
 		this.comments = collectComments ? new TreeMap<Long, String>() : Collections.<Long, String>emptyMap();
 		this.extractHeaders = settings.isHeaderExtractionEnabled();
 		this.whitespaceRangeStart = settings.getWhitespaceRangeStart();
+		this.commentLineCheck = settings.isCommentLineCheckEnabled();
 	}
 
 	protected void processComment() {
@@ -127,9 +130,11 @@ public abstract class AbstractParser<T extends CommonParserSettings<?>> {
 			while (!context.isStopped()) {
 				input.markRecordStart();
 				ch = input.nextChar();
-				if (inComment()) {
-					processComment();
-					continue;
+				if(commentLineCheck) {
+					if (inComment()) {
+						processComment();
+						continue;
+					}
 				}
 
 				if (output.pendingRecords.isEmpty()) {
@@ -566,9 +571,11 @@ public abstract class AbstractParser<T extends CommonParserSettings<?>> {
 			while (!context.isStopped()) {
 				input.markRecordStart();
 				ch = input.nextChar();
-				if (inComment()) {
-					processComment();
-					continue;
+				if(commentLineCheck) {
+					if (inComment()) {
+						processComment();
+						continue;
+					}
 				}
 				if (output.pendingRecords.isEmpty()) {
 					parseRecord();
@@ -672,9 +679,11 @@ public abstract class AbstractParser<T extends CommonParserSettings<?>> {
 			while (!context.isStopped()) {
 				input.markRecordStart();
 				ch = input.nextChar();
-				if (inComment()) {
-					processComment();
-					return null;
+				if(commentLineCheck) {
+					if (inComment()) {
+						processComment();
+						return null;
+					}
 				}
 				if (output.pendingRecords.isEmpty()) {
 					parseRecord();

--- a/src/main/java/com/univocity/parsers/common/CommonParserSettings.java
+++ b/src/main/java/com/univocity/parsers/common/CommonParserSettings.java
@@ -65,7 +65,7 @@ public abstract class CommonParserSettings<F extends Format> extends CommonSetti
 	private long numberOfRowsToSkip = 0L;
 	private boolean commentCollectionEnabled = false;
 	private boolean autoClosingEnabled = true;
-
+	private boolean commentLineCheckEnabled = true;
 	/**
 	 * Indicates whether or not a separate thread will be used to read characters from the input while parsing (defaults true if the number of available
 	 * processors at runtime is greater than 1)
@@ -493,4 +493,31 @@ public abstract class CommonParserSettings<F extends Format> extends CommonSetti
 	public void setAutoClosingEnabled(boolean autoClosingEnabled) {
 		this.autoClosingEnabled = autoClosingEnabled;
 	}
+
+	/**
+	 * Indicates whether code will check for comment line in the data file
+	 * is enabled. If {@code true}, the parser will always check for the comment line
+	 * default value for comment check is #
+	 * Defaults to {@code true}
+	 *
+	 * @return flag indicating whether parser will check for the comment line
+	 * If disabled/false then parser wont treat any line as comment line including default(#)
+	 * this condition will supersede the comment character(#)
+	 */
+	public boolean isCommentLineCheckEnabled() {
+		return commentLineCheckEnabled;
+	}
+
+	/**
+	 * Configures whether the parser will check for the comment line in the file
+	 * Defaults to {@code true}
+	 *
+	 * @param commentLineCheckEnabled flag determining whether comment line check should be performed
+	 *If disabled/false then parser wont treat any line as comment line including default(#)
+	 * this condition will supersede the comment character(#)
+	 */
+	public void setCommentLineCheckEnabled(boolean commentLineCheckEnabled) {
+		this.commentLineCheckEnabled = commentLineCheckEnabled;
+	}
+
 }

--- a/src/test/java/com/univocity/parsers/issues/github/Github_394.java
+++ b/src/test/java/com/univocity/parsers/issues/github/Github_394.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2018. Univocity Software Pty Ltd
+ * <p/>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.univocity.parsers.issues.github;
+
+import com.univocity.parsers.csv.*;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+/**
+ * From: https://github.com/univocity/univocity-parsers/issues/394
+ */
+public class Github_394 {
+
+
+	@Test
+	public void testEmptyValuesSpacesAndQuoting() {
+		CsvWriterSettings s = new CsvWriterSettings();
+		CsvFormat format = s.getFormat();
+		format.setLineSeparator("\n");
+		format.setDelimiter(',');
+		format.setQuote('\'');
+		format.setQuoteEscape('\\');
+		format.setComment('\u0000');
+
+		s.setIgnoreLeadingWhitespaces(true);
+		s.setIgnoreTrailingWhitespaces(true);
+		s.setNullValue("");
+		s.setEmptyValue("''");
+		s.setSkipEmptyLines(true);
+		s.setQuoteAllFields(false);
+		s.setQuoteEscapingEnabled(true);
+		s.setErrorContentLength(1000);
+		CsvWriter w = new CsvWriter(s);
+
+		String result = w.writeRowToString(1, "\n");
+		assertEquals(result, "1,''");
+	}
+
+	@Test
+	public void testParsingLineWithEnableCommentLineCheckToFalse() {
+		CsvParserSettings s = new CsvParserSettings();
+		CsvFormat format = s.getFormat();
+		format.setLineSeparator("\n");
+		format.setDelimiter(',');
+
+		s.setCommentLineCheckEnabled(false);
+		s.setIgnoreLeadingWhitespaces(true);
+		s.setIgnoreTrailingWhitespaces(true);
+		s.setNullValue("");
+		s.setEmptyValue("''");
+		s.setSkipEmptyLines(true);
+		s.setErrorContentLength(1000);
+		CsvParser parser = new CsvParser(s);
+
+		String[] result = parser.parseLine("#,2");
+		assertEquals(result.length, 2);
+		assertEquals(result[0], "#");
+		assertEquals(result[1], "2");
+	}
+}

--- a/src/test/java/com/univocity/parsers/issues/github/Github_394.java
+++ b/src/test/java/com/univocity/parsers/issues/github/Github_394.java
@@ -27,31 +27,6 @@ import static org.testng.Assert.assertEquals;
  */
 public class Github_394 {
 
-
-	@Test
-	public void testEmptyValuesSpacesAndQuoting() {
-		CsvWriterSettings s = new CsvWriterSettings();
-		CsvFormat format = s.getFormat();
-		format.setLineSeparator("\n");
-		format.setDelimiter(',');
-		format.setQuote('\'');
-		format.setQuoteEscape('\\');
-		format.setComment('\u0000');
-
-		s.setIgnoreLeadingWhitespaces(true);
-		s.setIgnoreTrailingWhitespaces(true);
-		s.setNullValue("");
-		s.setEmptyValue("''");
-		s.setSkipEmptyLines(true);
-		s.setQuoteAllFields(false);
-		s.setQuoteEscapingEnabled(true);
-		s.setErrorContentLength(1000);
-		CsvWriter w = new CsvWriter(s);
-
-		String result = w.writeRowToString(1, "\n");
-		assertEquals(result, "1,''");
-	}
-
 	@Test
 	public void testParsingLineWithEnableCommentLineCheckToFalse() {
 		CsvParserSettings s = new CsvParserSettings();


### PR DESCRIPTION
**What Changes Were Done**
Changes were done to handle the scenario where every line of record in a data file need to be treated as valid record including default comment character "#"
This change added a flag **commentLineCheckEnabled** which will be default to true. If user wants to treat every record as valid record including commented record(started with "#") then **commentLineCheckEnabled** can be set to false
**Why Changes Were Done**
In most of the data ware houshing scenarios files does not have comment records and every line needs to be treated as a valid record even though it starts with default comment character as #
Though user can set any comment character other than #, but there is a chance the actual record can start with those characters. So to handle this scenarios the above PR is raised
**What Unit testcases were written to check the scenarios**
In src/test/java/com/univocity/parsers/csv/CsvParserTest.java parseDisablingCommentLineCheck test case is added to check the overall file parsing by disabling the settings.setCommentLineCheckEnabled(false);
In Github_394 testParsingLineWithEnableCommentLineCheckToFalse test case is added to check the parseLine functionality
