### PR TITLE
Fix delimiters order when there is an unnecessary

### DIFF
--- a/src/main/java/com/univocity/parsers/csv/CsvFormatDetector.java
+++ b/src/main/java/com/univocity/parsers/csv/CsvFormatDetector.java
@@ -277,7 +277,7 @@ public abstract class CsvFormatDetector implements InputAnalysisProcess {
 				break out;
 			}
 
-			for (char c : allowedDelimiters) {
+			for (char c : delimiterPreference) {
 				if (c == delimiterMin) {
 					delimiter = delimiterMin;
 					break out;

--- a/src/test/java/com/univocity/parsers/csv/CsvFormatDetectorTest.java
+++ b/src/test/java/com/univocity/parsers/csv/CsvFormatDetectorTest.java
@@ -117,4 +117,18 @@ public class CsvFormatDetectorTest {
 		CsvFormat format = parser.getDetectedFormat();
 		assertEquals(format.getDelimiter(), ',');
 	}
+
+	@Test
+	public static void testDelimitersDetectedUsingOrderOfPreference1() {
+		String input = "HEADER 1,HEADER 2,HEADER 3\n" +
+						"SOME TEXT 1,SOME TEXT 2,SOME TEXT 3,";
+
+		CsvParserSettings settings = new CsvParserSettings();
+		settings.setDelimiterDetectionEnabled(true, ',', ' ');
+		settings.setFormatDetectorRowSampleCount(2);
+		CsvParser parser = new CsvParser(settings);
+		parser.parseAll(new StringReader(input));
+		CsvFormat format = parser.getDetectedFormat();
+		assertEquals(format.getDelimiter(), ',');
+	}
 }


### PR DESCRIPTION
If the row includes an unnecessary delimiter, the specified order of separators must be preserved