### PR TITLE
Issue #449: avoid ArrayIndexOutOfBoundsException in AbstractCharInputReader

### DIFF
--- a/src/main/java/com/univocity/parsers/common/input/AbstractCharInputReader.java
+++ b/src/main/java/com/univocity/parsers/common/input/AbstractCharInputReader.java
@@ -479,7 +479,7 @@ public abstract class AbstractCharInputReader implements CharInputReader {
 
 		if (trim) {
 			i = i - 2;
-			while (buffer[i] <= ' ' && whitespaceRangeStart < buffer[i]) {
+			while (i >= 0 && buffer[i] <= ' ' && whitespaceRangeStart < buffer[i]) {
 				len--;
 				i--;
 			}


### PR DESCRIPTION
A simple guard against the problem highlighted in Issue #449 