### PR TITLE
Writers should be Autocloseable

### DIFF
--- a/src/main/java/com/univocity/parsers/common/AbstractWriter.java
+++ b/src/main/java/com/univocity/parsers/common/AbstractWriter.java
@@ -49,7 +49,7 @@ import java.util.*;
  * @see com.univocity.parsers.common.input.WriterCharAppender
  * @see com.univocity.parsers.common.processor.RowWriterProcessor
  */
-public abstract class AbstractWriter<S extends CommonWriterSettings<?>> {
+public abstract class AbstractWriter<S extends CommonWriterSettings<?>> implements Autocloseable {
 
 	@SuppressWarnings("rawtypes")
 	private final RowWriterProcessor writerProcessor;

--- a/src/main/java/com/univocity/parsers/common/AbstractWriter.java
+++ b/src/main/java/com/univocity/parsers/common/AbstractWriter.java
@@ -989,6 +989,7 @@ public abstract class AbstractWriter<S extends CommonWriterSettings<?>> implemen
 	 * Closes the {@link java.io.Writer} given in this class constructor.
 	 * An IllegalStateException will be thrown in case of any errors.
 	 */
+	@Override
 	public final void close() {
 		try {
 			this.headerIndexes = null;


### PR DESCRIPTION
Autocloseable allows try-with-resource blocks for writers.