### PR TITLE
Snapshot version was incorrectly typed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.univocity</groupId>
 	<artifactId>univocity-parsers</artifactId>
-	<version>2.9.2-SNAPSOHT</version>
+	<version>2.9.2-SNAPSHOT</version>
 	<name>univocity-parsers</name>
 	<packaging>jar</packaging>
 	<description>univocity's open source parsers for processing different text formats using a consistent API</description>


### PR DESCRIPTION
It's now `SNAPSHOT` instead of `SNAPSOHT`