### PR TITLE
Add synchronized to ConcurrentCharLoader.stopReading() . Fixes #487

### DIFF
--- a/src/main/java/com/univocity/parsers/common/input/concurrent/ConcurrentCharLoader.java
+++ b/src/main/java/com/univocity/parsers/common/input/concurrent/ConcurrentCharLoader.java
@@ -171,7 +171,7 @@ class ConcurrentCharLoader implements Runnable {
 	/**
 	 * Stops the {@link CharBucket} loading process and closes the reader provided in the constructor of this class
 	 */
-	public void stopReading() {
+	public synchronized void stopReading() {
 		active = false;
 		try {
 			if(closeOnStop) {


### PR DESCRIPTION
This should address #487 . It's required since this method is called from multiple threads by this library. Alternatively, the callers mentioned in the issue could be fixed individually, but this seemed more reliable, simpler, and less likely to interfere with anything else.