### PR TITLE
Fix "reference to Record is ambiguous" build error on JDK 16 and above

### DIFF
--- a/src/main/java/com/univocity/parsers/common/AbstractParser.java
+++ b/src/main/java/com/univocity/parsers/common/AbstractParser.java
@@ -20,6 +20,7 @@ import com.univocity.parsers.common.input.*;
 import com.univocity.parsers.common.iterators.*;
 import com.univocity.parsers.common.processor.*;
 import com.univocity.parsers.common.processor.core.*;
+import com.univocity.parsers.common.record.Record;
 import com.univocity.parsers.common.record.*;
 
 import java.io.*;

--- a/src/main/java/com/univocity/parsers/common/AbstractWriter.java
+++ b/src/main/java/com/univocity/parsers/common/AbstractWriter.java
@@ -18,6 +18,7 @@ package com.univocity.parsers.common;
 import com.univocity.parsers.common.fields.*;
 import com.univocity.parsers.common.input.*;
 import com.univocity.parsers.common.processor.*;
+import com.univocity.parsers.common.record.Record;
 import com.univocity.parsers.common.record.*;
 import com.univocity.parsers.fixed.*;
 

--- a/src/main/java/com/univocity/parsers/common/Context.java
+++ b/src/main/java/com/univocity/parsers/common/Context.java
@@ -15,6 +15,7 @@
  ******************************************************************************/
 package com.univocity.parsers.common;
 
+import com.univocity.parsers.common.record.Record;
 import com.univocity.parsers.common.record.*;
 
 /**

--- a/src/main/java/com/univocity/parsers/common/ContextWrapper.java
+++ b/src/main/java/com/univocity/parsers/common/ContextWrapper.java
@@ -15,6 +15,7 @@
  ******************************************************************************/
 package com.univocity.parsers.common;
 
+import com.univocity.parsers.common.record.Record;
 import com.univocity.parsers.common.record.*;
 
 /**

--- a/src/main/java/com/univocity/parsers/common/DefaultContext.java
+++ b/src/main/java/com/univocity/parsers/common/DefaultContext.java
@@ -15,6 +15,7 @@
  */
 package com.univocity.parsers.common;
 
+import com.univocity.parsers.common.record.Record;
 import com.univocity.parsers.common.record.*;
 
 /**

--- a/src/main/java/com/univocity/parsers/common/NoopParsingContext.java
+++ b/src/main/java/com/univocity/parsers/common/NoopParsingContext.java
@@ -15,6 +15,7 @@
  ******************************************************************************/
 package com.univocity.parsers.common;
 
+import com.univocity.parsers.common.record.Record;
 import com.univocity.parsers.common.record.*;
 
 import java.util.*;

--- a/src/main/java/com/univocity/parsers/common/ParsingContextWrapper.java
+++ b/src/main/java/com/univocity/parsers/common/ParsingContextWrapper.java
@@ -15,6 +15,7 @@
  */
 package com.univocity.parsers.common;
 
+import com.univocity.parsers.common.record.Record;
 import com.univocity.parsers.common.record.*;
 
 import java.util.*;

--- a/src/main/java/com/univocity/parsers/common/iterators/RecordIterator.java
+++ b/src/main/java/com/univocity/parsers/common/iterators/RecordIterator.java
@@ -16,6 +16,7 @@
 package com.univocity.parsers.common.iterators;
 
 import com.univocity.parsers.common.*;
+import com.univocity.parsers.common.record.Record;
 import com.univocity.parsers.common.record.*;
 
 import java.io.*;

--- a/src/main/java/com/univocity/parsers/fixed/FixedWidthParser.java
+++ b/src/main/java/com/univocity/parsers/fixed/FixedWidthParser.java
@@ -17,6 +17,7 @@ package com.univocity.parsers.fixed;
 
 import com.univocity.parsers.common.*;
 import com.univocity.parsers.common.input.*;
+import com.univocity.parsers.common.record.Record;
 import com.univocity.parsers.common.record.*;
 
 /**

--- a/src/main/java/com/univocity/parsers/fixed/Lookup.java
+++ b/src/main/java/com/univocity/parsers/fixed/Lookup.java
@@ -16,6 +16,7 @@
 package com.univocity.parsers.fixed;
 
 import com.univocity.parsers.common.*;
+import com.univocity.parsers.common.record.Record;
 import com.univocity.parsers.common.record.*;
 
 import java.util.*;


### PR DESCRIPTION
The commit in this pull request fixes compiler errors like the following one when this project is being built using JDK 16 or above:
```
src/main/java/com/univocity/parsers/common/Context.java:136: error: reference to Record is ambiguous
        Record toRecord(String[] row);
        ^
  both interface com.univocity.parsers.common.record.Record in com.univocity.parsers.common.record and class java.lang.Record in java.lang match
```
More details are explained in the commit message.

Although this project's `pom.xml` still declares Java 1.6 as the compilation source/target, which means that it cannot be built using JDK 12+ yet, this change would still make this project more future-proof under all circumstances.  It eliminates one issue you folks would encounter when you decide to support JDK 17 for the latest LTS release of Java.  Even if you wish to stay on older Java versions for an extended period, this commit is backward-compatible with older JDK versions and does not introduce any regression both theoretically and practically according to my testing.

For what it is worth, the aforementioned compiler errors were discovered when we packaged this project for a GNU/Linux distribution (https://github.com/Leo3418/junit-5-ebuild-repo/issues/4).  We, as distribution maintainers, often use a more up-to-date version of JDK to build packages for various Java projects:
- Fedora has already switched to Java 11 (https://fedoraproject.org/wiki/Changes/Java11) is planning to transition further to Java 17 for their upcoming Fedora 36 release (https://fedoraproject.org/wiki/Changes/Java17)
- Gentoo's effort to migrate to Java 11 is almost complete (https://bugs.gentoo.org/show_bug.cgi?id=jdk11) and is also starting to support Java 17 (https://bugs.gentoo.org/show_bug.cgi?id=jdk17)

Therefore, we, as maintainers of those distributions, would appreciate your attention to support for the newer JDK versions.