### PR TITLE
add an option for quoting values of the first column that start with the comment character #505

### DIFF
--- a/src/main/java/com/univocity/parsers/common/AbstractWriter.java
+++ b/src/main/java/com/univocity/parsers/common/AbstractWriter.java
@@ -204,7 +204,7 @@ public abstract class AbstractWriter<S extends CommonWriterSettings<?>> {
 		this.expandRows = settings.getExpandIncompleteRows();
 		this.columnReorderingEnabled = settings.isColumnReorderingEnabled();
 		this.whitespaceRangeStart = settings.getWhitespaceRangeStart();
-		this.quoteCommentStartingFirstColumn = settings.isColumnReorderingEnabled();
+		this.quoteCommentStartingFirstColumn = settings.isQuoteCommentStartingFirstColumnEnabled();
 		this.appender = new WriterCharAppender(settings.getMaxCharsPerColumn(), "", whitespaceRangeStart, settings.getFormat());
 		this.rowAppender = new WriterCharAppender(settings.getMaxCharsPerColumn(), "", whitespaceRangeStart, settings.getFormat());
 

--- a/src/main/java/com/univocity/parsers/common/AbstractWriter.java
+++ b/src/main/java/com/univocity/parsers/common/AbstractWriter.java
@@ -96,7 +96,7 @@ public abstract class AbstractWriter<S extends CommonWriterSettings<?>> {
 	};
 	private final int errorContentLength;
 
-	protected final boolean quoteCommentStartingFirstColumn;
+	protected final boolean processComments;
 
 	/**
 	 * All writers must support, at the very least, the settings provided by {@link CommonWriterSettings}. The AbstractWriter requires its configuration to be
@@ -204,7 +204,7 @@ public abstract class AbstractWriter<S extends CommonWriterSettings<?>> {
 		this.expandRows = settings.getExpandIncompleteRows();
 		this.columnReorderingEnabled = settings.isColumnReorderingEnabled();
 		this.whitespaceRangeStart = settings.getWhitespaceRangeStart();
-		this.quoteCommentStartingFirstColumn = settings.isQuoteCommentStartingFirstColumnEnabled();
+		this.processComments = settings.isCommentProcessingEnabled();
 		this.appender = new WriterCharAppender(settings.getMaxCharsPerColumn(), "", whitespaceRangeStart, settings.getFormat());
 		this.rowAppender = new WriterCharAppender(settings.getMaxCharsPerColumn(), "", whitespaceRangeStart, settings.getFormat());
 

--- a/src/main/java/com/univocity/parsers/common/AbstractWriter.java
+++ b/src/main/java/com/univocity/parsers/common/AbstractWriter.java
@@ -96,6 +96,8 @@ public abstract class AbstractWriter<S extends CommonWriterSettings<?>> {
 	};
 	private final int errorContentLength;
 
+	protected final boolean quoteCommentStartingFirstColumn;
+
 	/**
 	 * All writers must support, at the very least, the settings provided by {@link CommonWriterSettings}. The AbstractWriter requires its configuration to be
 	 * properly initialized.
@@ -202,6 +204,7 @@ public abstract class AbstractWriter<S extends CommonWriterSettings<?>> {
 		this.expandRows = settings.getExpandIncompleteRows();
 		this.columnReorderingEnabled = settings.isColumnReorderingEnabled();
 		this.whitespaceRangeStart = settings.getWhitespaceRangeStart();
+		this.quoteCommentStartingFirstColumn = settings.isColumnReorderingEnabled();
 		this.appender = new WriterCharAppender(settings.getMaxCharsPerColumn(), "", whitespaceRangeStart, settings.getFormat());
 		this.rowAppender = new WriterCharAppender(settings.getMaxCharsPerColumn(), "", whitespaceRangeStart, settings.getFormat());
 

--- a/src/main/java/com/univocity/parsers/common/CommonWriterSettings.java
+++ b/src/main/java/com/univocity/parsers/common/CommonWriterSettings.java
@@ -49,6 +49,8 @@ public abstract class CommonWriterSettings<F extends Format> extends CommonSetti
 
 	private boolean columnReorderingEnabled = false;
 
+	private boolean quoteCommentStartingFirstColumnEnabled = true;
+
 	/**
 	 * Returns the String representation of an empty value (defaults to null)
 	 *
@@ -227,5 +229,28 @@ public abstract class CommonWriterSettings<F extends Format> extends CommonSetti
 	 */
 	public void setColumnReorderingEnabled(boolean columnReorderingEnabled) {
 		this.columnReorderingEnabled = columnReorderingEnabled;
+	}
+
+	/**
+	 * Indicates the writer will quote values of the first column that start with the comment character in the file
+	 * is enabled. If {@code true}, the writer will always quote values of the first column that start with the comment character
+	 * Defaults to {@code true}
+	 *
+	 * @return flag indicating whether writer will always quote values of the first column that start with the comment character
+	 * If disabled/false then parser wont quote values of the first column that start with the comment character
+	 */
+	public boolean isQuoteCommentStartingFirstColumnEnabled() {
+		return quoteCommentStartingFirstColumnEnabled;
+	}
+
+	/**
+	 * Configures whether the writer will quote values of the first column that start with the comment character in the file
+	 * Defaults to {@code true}
+	 *
+	 * @param quoteCommentStartingFirstColumnEnabled flag determining whether the writer will quote values of the first
+	 *                                                  column that start with the comment character in the file
+	 */
+	public void setQuoteCommentStartingFirstColumnEnabled(boolean quoteCommentStartingFirstColumnEnabled) {
+		this.quoteCommentStartingFirstColumnEnabled = quoteCommentStartingFirstColumnEnabled;
 	}
 }

--- a/src/main/java/com/univocity/parsers/common/CommonWriterSettings.java
+++ b/src/main/java/com/univocity/parsers/common/CommonWriterSettings.java
@@ -233,22 +233,22 @@ public abstract class CommonWriterSettings<F extends Format> extends CommonSetti
 
 	/**
 	 * Indicates whether the writer will check for comment lines is enabled.
-	 * If {@code true}, the writer will always quote values of the first column that start with the comment character
+	 * If {@code true}, the writer will always quote values of the first column that start with the comment character.
 	 * Defaults to {@code true}
 	 *
 	 * @return flag indicating whether the writer will check for comment lines
-	 * If disabled/false then writer wont quote values of the first column that start with the comment character
+	 * If disabled/false then writer wont quote values of the first column that start with the comment character.
 	 */
 	public boolean isCommentProcessingEnabled() {
 		return commentProcessingEnabled;
 	}
 
 	/**
-	 * Configures whether the writer will check for comment lines
+	 * Configures whether the writer will check for comment lines.
 	 * Defaults to {@code true}
 	 *
 	 * @param commentProcessingEnabled flag determining whether comment lines check should be performed
-	 *                                 If disabled/false then writer wont quote values of the first column that start with the comment character
+	 *                                 If disabled/false then writer wont quote values of the first column that start with the comment character.
 	 */
 	public void setCommentProcessingEnabled(boolean commentProcessingEnabled) {
 		this.commentProcessingEnabled = commentProcessingEnabled;

--- a/src/main/java/com/univocity/parsers/common/CommonWriterSettings.java
+++ b/src/main/java/com/univocity/parsers/common/CommonWriterSettings.java
@@ -49,7 +49,7 @@ public abstract class CommonWriterSettings<F extends Format> extends CommonSetti
 
 	private boolean columnReorderingEnabled = false;
 
-	private boolean quoteCommentStartingFirstColumnEnabled = true;
+	private boolean commentProcessingEnabled = true;
 
 	/**
 	 * Returns the String representation of an empty value (defaults to null)
@@ -232,25 +232,25 @@ public abstract class CommonWriterSettings<F extends Format> extends CommonSetti
 	}
 
 	/**
-	 * Indicates the writer will quote values of the first column that start with the comment character in the file
-	 * is enabled. If {@code true}, the writer will always quote values of the first column that start with the comment character
+	 * Indicates whether the writer will check for comment lines is enabled.
+	 * If {@code true}, the writer will always quote values of the first column that start with the comment character
 	 * Defaults to {@code true}
 	 *
-	 * @return flag indicating whether writer will always quote values of the first column that start with the comment character
-	 * If disabled/false then parser wont quote values of the first column that start with the comment character
+	 * @return flag indicating whether the writer will check for comment lines
+	 * If disabled/false then writer wont quote values of the first column that start with the comment character
 	 */
-	public boolean isQuoteCommentStartingFirstColumnEnabled() {
-		return quoteCommentStartingFirstColumnEnabled;
+	public boolean isCommentProcessingEnabled() {
+		return commentProcessingEnabled;
 	}
 
 	/**
-	 * Configures whether the writer will quote values of the first column that start with the comment character in the file
+	 * Configures whether the writer will check for comment lines
 	 * Defaults to {@code true}
 	 *
-	 * @param quoteCommentStartingFirstColumnEnabled flag determining whether the writer will quote values of the first
-	 *                                                  column that start with the comment character in the file
+	 * @param commentProcessingEnabled flag determining whether comment lines check should be performed
+	 *                                 If disabled/false then writer wont quote values of the first column that start with the comment character
 	 */
-	public void setQuoteCommentStartingFirstColumnEnabled(boolean quoteCommentStartingFirstColumnEnabled) {
-		this.quoteCommentStartingFirstColumnEnabled = quoteCommentStartingFirstColumnEnabled;
+	public void setCommentProcessingEnabled(boolean commentProcessingEnabled) {
+		this.commentProcessingEnabled = commentProcessingEnabled;
 	}
 }

--- a/src/main/java/com/univocity/parsers/csv/CsvWriter.java
+++ b/src/main/java/com/univocity/parsers/csv/CsvWriter.java
@@ -320,7 +320,7 @@ public class CsvWriter extends AbstractWriter<CsvWriterSettings> {
 		}
 
 		final int length = element.length();
-		if (start < length && (element.charAt(start) == quoteChar || columnIndex == 0 && element.charAt(0) == comment && quoteCommentStartingFirstColumn)) {
+		if (start < length && (element.charAt(start) == quoteChar || columnIndex == 0 && element.charAt(0) == comment && processComments)) {
 			isElementQuoted = true;
 		}
 

--- a/src/main/java/com/univocity/parsers/csv/CsvWriter.java
+++ b/src/main/java/com/univocity/parsers/csv/CsvWriter.java
@@ -320,7 +320,7 @@ public class CsvWriter extends AbstractWriter<CsvWriterSettings> {
 		}
 
 		final int length = element.length();
-		if (start < length && (element.charAt(start) == quoteChar || columnIndex == 0 && element.charAt(0) == comment)) {
+		if (start < length && (element.charAt(start) == quoteChar || columnIndex == 0 && element.charAt(0) == comment && quoteCommentStartingFirstColumn)) {
 			isElementQuoted = true;
 		}
 

--- a/src/test/java/com/univocity/parsers/issues/github/Github_505.java
+++ b/src/test/java/com/univocity/parsers/issues/github/Github_505.java
@@ -19,29 +19,24 @@ public class Github_505 {
 
 	@Test
 	public void testCommentCharWriting() {
-		StringWriter sw = new StringWriter();
+		StringWriter sw1 = new StringWriter();
 		{
 			CsvWriterSettings writerSettings = new CsvWriterSettings();
-			writerSettings.setQuoteCommentStartingFirstColumnEnabled(false);
-			CsvWriter writer = new CsvWriter(sw, writerSettings);
-			writer.writeRow(new String[]{"#field1", "field2", "field3"});
+			writerSettings.setCommentProcessingEnabled(false);
+			CsvWriter writer = new CsvWriter(sw1, writerSettings);
+			writer.writeRow(new String[]{"#field1", "field2"});
 			writer.close();
 		}
-		StringReader sr1 = new StringReader(sw.toString());
+		assertEquals(sw1.toString(), "#field1,field2\n");
+
+		StringWriter sw2 = new StringWriter();
 		{
-			CsvParserSettings parserSettings = new CsvParserSettings();
-			CsvParser parser = new CsvParser(parserSettings);
-			List<String[]> rows = parser.parseAll(sr1);
-			assertEquals(rows.size(), 0);
+			CsvWriterSettings writerSettings = new CsvWriterSettings();
+			writerSettings.setCommentProcessingEnabled(true);
+			CsvWriter writer = new CsvWriter(sw2, writerSettings);
+			writer.writeRow(new String[]{"#field1", "field2"});
+			writer.close();
 		}
-		StringReader sr2 = new StringReader(sw.toString());
-		{
-			CsvParserSettings parserSettings = new CsvParserSettings();
-			parserSettings.setCommentProcessingEnabled(false);
-			CsvParser parser = new CsvParser(parserSettings);
-			List<String[]> rows = parser.parseAll(sr2);
-			String[] row = rows.get(0);
-			assertEquals(row[0], "#field1");
-		}
+		assertEquals(sw2.toString(), "\"#field1\",field2\n");
 	}
 }

--- a/src/test/java/com/univocity/parsers/issues/github/Github_505.java
+++ b/src/test/java/com/univocity/parsers/issues/github/Github_505.java
@@ -1,0 +1,47 @@
+package com.univocity.parsers.issues.github;
+
+import com.univocity.parsers.csv.CsvParser;
+import com.univocity.parsers.csv.CsvParserSettings;
+import com.univocity.parsers.csv.CsvWriter;
+import com.univocity.parsers.csv.CsvWriterSettings;
+import org.testng.annotations.Test;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * From: https://github.com/uniVocity/univocity-parsers/issues/505
+ */
+public class Github_505 {
+
+	@Test
+	public void testCommentCharWriting() {
+		StringWriter sw = new StringWriter();
+		{
+			CsvWriterSettings writerSettings = new CsvWriterSettings();
+			writerSettings.setQuoteCommentStartingFirstColumnEnabled(false);
+			CsvWriter writer = new CsvWriter(sw, writerSettings);
+			writer.writeRow(new String[]{"#field1", "field2", "field3"});
+			writer.close();
+		}
+		StringReader sr1 = new StringReader(sw.toString());
+		{
+			CsvParserSettings parserSettings = new CsvParserSettings();
+			CsvParser parser = new CsvParser(parserSettings);
+			List<String[]> rows = parser.parseAll(sr1);
+			assertEquals(rows.size(), 0);
+		}
+		StringReader sr2 = new StringReader(sw.toString());
+		{
+			CsvParserSettings parserSettings = new CsvParserSettings();
+			parserSettings.setCommentProcessingEnabled(false);
+			CsvParser parser = new CsvParser(parserSettings);
+			List<String[]> rows = parser.parseAll(sr2);
+			String[] row = rows.get(0);
+			assertEquals(row[0], "#field1");
+		}
+	}
+}


### PR DESCRIPTION
Problem:

After #362 and [related commit ](https://github.com/uniVocity/univocity-parsers/commit/d1137a44b5c72c2834f338d1dddeb058e45f24a2)，first column that start with the comment character will be written with quotes.
It makes a breaking change to users downstream that handing a whole row as input, #505 mentioned.

This pr amis to fix #505 .