### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -243,7 +243,7 @@
 		<dependency>
 			<groupId>org.hsqldb</groupId>
 			<artifactId>hsqldb</artifactId>
-			<version>2.3.2</version>
+			<version>2.7.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
The current version has a [CVE-2022-41853](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-41853) vulnerability. So, I propose an update to the latest version 2.7.2 to fix it.