### PR TITLE
Fix incorrect results when ascii-control characters are used as Quote and Escape

### DIFF
--- a/src/main/java/com/univocity/parsers/csv/CsvParser.java
+++ b/src/main/java/com/univocity/parsers/csv/CsvParser.java
@@ -379,12 +379,12 @@ public final class CsvParser extends AbstractParser<CsvParserSettings> {
 			}
 			ch = input.nextChar();
 
-			if (trimQuotedLeading && ch <= ' ' && output.appender.length() == 0) {
+			if (trimQuotedLeading && (ch <= ' ' && ch != quote && ch != quoteEscape) && output.appender.length() == 0) {
 				while ((ch = input.nextChar()) <= ' ') ;
 			}
 
 			while (true) {
-				if (prev == quote && (ch <= ' ' && whitespaceRangeStart < ch || ch == delimiter || ch == newLine)) {
+				if (prev == quote && ((ch <= ' ' && ch != quote && ch != quoteEscape) && whitespaceRangeStart < ch || ch == delimiter || ch == newLine)) {
 					break;
 				}
 

--- a/src/test/java/com/univocity/parsers/csv/CsvParserTest.java
+++ b/src/test/java/com/univocity/parsers/csv/CsvParserTest.java
@@ -907,5 +907,21 @@ public class CsvParserTest extends ParserTestCase {
 		assertEquals(comments.size(), 0);
 		assertEquals(parser.getContext().lastComment(), null);
 	}
-
+	@Test
+	public void asciiControlCharAsQuoteAndEscape() {
+		final Reader csv = new StringReader("\u00127\u0012," +
+				"\u0012EmbeddedDouble\u0012," +
+				"\u0012field\u0012\u0012 t\u0012\u0012ext\u0012," +
+				"\u0012field\u0012\u0012 t\u0012\u0012ext\u0012");
+		final CsvParserSettings settings = new CsvParserSettings();
+		settings.getFormat().setQuote('\u0012');
+		settings.getFormat().setQuoteEscape('\u0012');
+		settings.setUnescapedQuoteHandling(UnescapedQuoteHandling.STOP_AT_CLOSING_QUOTE);
+		final CsvParser csvParser = new CsvParser(settings);
+		final String[] row = csvParser.parseAll(csv).get(0);
+		assertEquals(row[0], "7");
+		assertEquals(row[1], "EmbeddedDouble");
+		assertEquals(row[2], "field\u0012 t\u0012ext");
+		assertEquals(row[3], "field\u0012 t\u0012ext");
+	}
 }


### PR DESCRIPTION
As titled, without this fix incorrect results are created:
```
final Reader csv = new StringReader("\u00127\u0012," +
				"\u0012EmbeddedDouble\u0012," +
				"\u0012field\u0012\u0012 t\u0012\u0012ext\u0012," +
				"\u0012field\u0012\u0012 t\u0012\u0012ext\u0012");
final CsvParserSettings settings = new CsvParserSettings();
settings.getFormat().setQuote('\u0012');
settings.getFormat().setQuoteEscape('\u0012');
settings.setUnescapedQuoteHandling(UnescapedQuoteHandling.STOP_AT_CLOSING_QUOTE);
final CsvParser csvParser = new CsvParser(settings);
final String[] row = csvParser.parseAll(csv).get(0);
// row: ["7", "EmbeddedDouble", "field\u0012\u0012 t\u0012\u0012ext", "field\u0012\u0012 t\u0012\u0012ext"]
// expect ["7", "EmbeddedDouble", "field\u0012 t\u0012ext", "field\u0012 t\u0012ext"]
```
while it should be the one in the added unit test.