### PR TITLE
Sorting annotation to avoid executing booleanString before trim

### DIFF
--- a/src/main/java/com/univocity/parsers/annotations/helpers/AnnotationHelper.java
+++ b/src/main/java/com/univocity/parsers/annotations/helpers/AnnotationHelper.java
@@ -1132,16 +1132,23 @@ public class AnnotationHelper {
 
 	private static void findAllAnnotationsInPackage(AnnotatedElement annotatedElement, Package aPackage, ArrayList<? super Annotation> found, Set<Annotation> visited) {
 		Annotation[] declaredAnnotations = annotatedElement.getDeclaredAnnotations();
-
+		List<Annotation> otherAnnotations = new ArrayList<Annotation>();
+		List<Annotation> booleanStringAnnotations = new ArrayList<Annotation>();
 		for (int i = 0; i < declaredAnnotations.length; i++) {
 			Annotation ann = declaredAnnotations[i];
 			if (aPackage.equals(ann.annotationType().getPackage())) {
-				found.add(ann);
+				if (ann.annotationType().equals(BooleanString.class)) {
+					booleanStringAnnotations.add(ann);
+				} else {
+					otherAnnotations.add(ann);
+				}
 			}
 			if (isCustomAnnotation(ann) && visited.add(ann)) {
 				findAllAnnotationsInPackage(ann.annotationType(), aPackage, found, visited);
 			}
 		}
+		found.addAll(otherAnnotations);
+		found.addAll(booleanStringAnnotations);
 	}
 
 	/**


### PR DESCRIPTION
### Issue:
When I run the test com.univocity.parsers.common.processor.MultiBeanListProcessorTest.testAnnotatedBeanProcessor, I met the error:
![2aa66d0d92cdae3b8bd0b5b8c4fe01f](https://github.com/user-attachments/assets/b2f7b1b2-a417-4f3f-98b6-07566a2beb29)

### Reason:
Class TestBean has two attributes "pending" and "other". The attribute used both trim and booleanString. Since getDeclaredAnnotations doesn't ensure order, it may happen BooleanString is executed first and then trim is executed. This will cause errors that call trim on Boolean type.

### Changes:
In the AnnotationHelp, add logic to sort BooleanString at the end of "found" array.