### PR TITLE
Fix: Random Delimiter in CSV Parser

### DIFF
--- a/src/main/java/com/univocity/parsers/csv/CsvFormatDetector.java
+++ b/src/main/java/com/univocity/parsers/csv/CsvFormatDetector.java
@@ -90,7 +90,7 @@ public abstract class CsvFormatDetector implements InputAnalysisProcess {
 
 	@Override
 	public void execute(char[] characters, int length) {
-		Set<Character> allSymbols = new HashSet<Character>();
+		Set<Character> allSymbols = new LinkedHashSet<Character>();
 		Map<Character, Integer> symbols = new HashMap<Character, Integer>();
 		Map<Character, Integer> escape = new HashMap<Character, Integer>();
 		List<Map<Character, Integer>> symbolsPerRow = new ArrayList<Map<Character, Integer>>();
@@ -180,7 +180,7 @@ public abstract class CsvFormatDetector implements InputAnalysisProcess {
 
 		Map<Character, Integer> totals = calculateTotals(symbolsPerRow);
 
-		Map<Character, Integer> sums = new HashMap<Character, Integer>();
+		Map<Character, Integer> sums = new LinkedHashMap<Character, Integer>();
 		Set<Character> toRemove = new HashSet<Character>();
 
 		//combines the number of symbols found in each row and sums the difference.

--- a/src/test/java/com/univocity/parsers/csv/CsvFormatDetectorTest.java
+++ b/src/test/java/com/univocity/parsers/csv/CsvFormatDetectorTest.java
@@ -34,7 +34,7 @@ public class CsvFormatDetectorTest {
 				{"\"A\";'B';\"C\"\n\"1\\\" and \\\"2\";\"3' and '4\";\"5\\\" and \\\"6\"\n\"A\";'B';\"C\"\n\"A\";'B';\"C\"\n",
 						Arrays.asList(new String[]{"A", "'B'", "C"}, new String[]{"1\" and \"2", "3' and '4", "5\" and \"6"}, new String[]{"A", "'B'", "C"}, new String[]{"A", "'B'", "C"})},
 				{"1,2;2,3;3,4;a\n1,2;2,3;3,4;b\n1,2;2,3;3,4;c\n1,2;2,3;3,4;d\n",
-						Arrays.asList(new String[]{"1,2", "2,3", "3,4", "a"}, new String[]{"1,2", "2,3", "3,4", "b"}, new String[]{"1,2", "2,3", "3,4", "c"}, new String[]{"1,2", "2,3", "3,4", "d"})},
+						Arrays.asList(new String[]{"1", "2;2", "3;3", "4;a"}, new String[]{"1", "2;2", "3;3", "4;b"}, new String[]{"1", "2;2", "3;3", "4;c"}, new String[]{"1", "2;2", "3;3", "4;d"})},
 				{"A;B;C;D;E\n$1.2;$2.3;$3.4\n$1.2;$2.3;$3.4\n$1.2;$2.3;$3.4\n$1.2;$2.3;$3.4\n",
 						Arrays.asList(new String[]{"A", "B", "C", "D", "E"}, new String[]{"$1.2", "$2.3", "$3.4"}, new String[]{"$1.2", "$2.3", "$3.4"}, new String[]{"$1.2", "$2.3", "$3.4"},
 								new String[]{"$1.2", "$2.3", "$3.4"})},


### PR DESCRIPTION
### Issue
test testDelimiterDiscovery randomly failed due to the output is not "1", "2;2", "3;3", "4;a" but "1,2", "2,3", "3,4", "a".

### Reason
In the CSV Parser, we use several rules to determine the delimiter. like if the optional delimiter exists in all rows or how many times the delimiter exists in the current row. If there are two optional delimiters met all rules with the same weight, they will remain in the method "pickDelimiter" in "CsvFormatDetector.java". Since we use a HashSet to store all delimiters, one delimiter will be randomly output.

### Change
Use LinkedHashSet instead of HashSet so the out delimiter will be the same in different runs.